### PR TITLE
DEV-245/feedback-on-xlf-files

### DIFF
--- a/algebras/commands/healthcheck_command.py
+++ b/algebras/commands/healthcheck_command.py
@@ -237,7 +237,8 @@ def validate_file_pair(source_file: str, target_file: str, source_language: str,
                     
                     # Only check if target is translated (non-empty)
                     if target_value and target_value.strip():
-                        key_issues = validate_translation(source_value, target_value, key)
+                        is_xliff = source_file.endswith(('.xlf', '.xliff'))
+                        key_issues = validate_translation(source_value, target_value, key, is_xliff=is_xliff)
                         issues.extend(key_issues)
                         keys_checked += 1
                         # Track keys with issues
@@ -269,7 +270,8 @@ def validate_file_pair(source_file: str, target_file: str, source_language: str,
                         
                         # Only check if target is translated (non-empty)
                         if target_value and target_value.strip():
-                            key_issues = validate_translation(source_value, target_value, key)
+                            is_xliff = target_file.endswith(('.xlf', '.xliff'))
+                            key_issues = validate_translation(source_value, target_value, key, is_xliff=is_xliff)
                             issues.extend(key_issues)
                             keys_checked += 1
                             # Track keys with issues
@@ -294,7 +296,8 @@ def validate_file_pair(source_file: str, target_file: str, source_language: str,
                         # Only check string values that are translated
                         if isinstance(source_value, str) and isinstance(target_value, str):
                             if target_value and target_value.strip():
-                                key_issues = validate_translation(source_value, target_value, key)
+                                is_xliff = target_file.endswith(('.xlf', '.xliff'))
+                                key_issues = validate_translation(source_value, target_value, key, is_xliff=is_xliff)
                                 issues.extend(key_issues)
                                 keys_checked += 1
                                 # Track keys with issues

--- a/algebras/commands/translate_command.py
+++ b/algebras/commands/translate_command.py
@@ -926,7 +926,7 @@ def execute(language: Optional[str] = None, force: bool = False, only_missing: b
                                     target_content_raw = {'version': source_content_raw['version'], 'files': []}
                                 else:
                                     target_content_raw = {'version': xlf_version, 'files': []}
-                            updated_content = update_xliff_targets(target_content_raw, translated_content, source_content_raw, xlf_target_state)
+                            updated_content = update_xliff_targets(target_content_raw, translated_content, source_content_raw, xlf_target_state, only_missing=True)
                             # Ensure version is set in updated content
                             if 'version' not in updated_content:
                                 updated_content['version'] = xlf_version

--- a/algebras/commands/translate_command.py
+++ b/algebras/commands/translate_command.py
@@ -125,8 +125,9 @@ def execute(language: Optional[str] = None, force: bool = False, only_missing: b
     
     # Initialize translator
     translator = Translator(config=config)
+    translator.set_verbose(verbose)
     if verbose:
-        click.echo(f"{Fore.BLUE}Initialized translator\x1b[0m")
+        click.echo(f"{Fore.BLUE}Initialized translator with verbose mode\x1b[0m")
     
     # Handle custom prompt from file or config
     custom_prompt = None
@@ -1036,6 +1037,39 @@ def execute(language: Optional[str] = None, force: bool = False, only_missing: b
                         from algebras.utils.csv_handler import add_language_to_csv
                         updated_csv = add_language_to_csv(existing_csv, mapped_target_lang, translated_content)
                         write_csv_file(target_file, updated_csv)
+                    elif source_file.endswith((".xlf", ".xliff")):
+                        # For XLIFF files, extract strings, translate, then update structure
+                        # Don't use translator.translate_file() as it returns structured dict, not flat translations
+                        source_content_raw = read_xliff_file(source_file)
+                        # Extract flat translatable strings
+                        source_content = extract_xliff_strings(source_content_raw)
+                        
+                        # Translate the flat dictionary
+                        translated_content = translator._translate_flat_dict(
+                            source_content, 
+                            source_language, 
+                            target_lang, 
+                            ui_safe, 
+                            glossary_id
+                        )
+                        
+                        # Create empty target structure with version from source
+                        target_version = source_content_raw.get('version', xlf_version) if source_content_raw else xlf_version
+                        target_content_raw = {'version': target_version, 'files': []}
+                        if verbose:
+                            click.echo(f"  {Fore.CYAN}Creating new XLIFF file with version {target_version} and state '{xlf_target_state}'\x1b[0m")
+                            # Show sample translations
+                            sample_count = min(3, len(translated_content))
+                            if sample_count > 0:
+                                click.echo(f"  {Fore.CYAN}Sample translations:{Fore.RESET}")
+                                for i, (key, value) in enumerate(list(translated_content.items())[:sample_count]):
+                                    source_value = source_content.get(key, '')
+                                    click.echo(f"    {key[:30]}... : '{source_value[:40]}...' → '{value[:40]}...'")
+                        
+                        # Use update_xliff_targets to properly structure the content and add state
+                        updated_content = update_xliff_targets(target_content_raw, translated_content, source_content_raw, xlf_target_state)
+                        write_xliff_file(target_file, updated_content, source_language, target_lang, xlf_target_state)
+                        click.echo(f"  {Fore.GREEN}✓ Saved to {target_file}\x1b[0m")
                     else:
                         # For other file types, use the normal translation flow
                         translated_content = translator.translate_file(source_file, target_lang, ui_safe, glossary_id)
@@ -1059,22 +1093,6 @@ def execute(language: Optional[str] = None, force: bool = False, only_missing: b
                             write_po_file(target_file, translated_content, po_mark_fuzzy)
                         elif source_file.endswith(".html"):
                             write_html_file(target_file, source_file, translated_content)
-                        elif source_file.endswith((".xlf", ".xliff")):
-                            # For XLIFF files, we need to use the structured format to properly add state
-                            # Read source file to get structure, then use update_xliff_targets
-                            source_content_raw = read_xliff_file(source_file)
-                            # Create empty target structure with version from source
-                            target_version = source_content_raw.get('version', xlf_version) if source_content_raw else xlf_version
-                            target_content_raw = {'version': target_version, 'files': []}
-                            if verbose:
-                                click.echo(f"  {Fore.CYAN}Creating new XLIFF file with version {target_version} and state '{xlf_target_state}'\x1b[0m")
-                            # Filter out any metadata keys (like 'version') from translated_content before processing
-                            # These shouldn't be treated as translation units
-                            filtered_translations = {k: v for k, v in translated_content.items() 
-                                                   if k != 'version' and isinstance(v, str)}
-                            # Use update_xliff_targets to properly structure the content and add state
-                            updated_content = update_xliff_targets(target_content_raw, filtered_translations, source_content_raw, xlf_target_state)
-                            write_xliff_file(target_file, updated_content, source_language, target_lang, xlf_target_state)
                         
                         click.echo(f"  {Fore.GREEN}✓ Saved to {target_file}\x1b[0m")
         

--- a/algebras/commands/translate_command.py
+++ b/algebras/commands/translate_command.py
@@ -75,13 +75,21 @@ def execute(language: Optional[str] = None, force: bool = False, only_missing: b
     
     # Get XLIFF target state from config (default: "translated")
     xlf_target_state = config.get_setting("xlf.default_target_state", "translated")
+    if verbose:
+        click.echo(f"{Fore.BLUE}XLIFF target state: {xlf_target_state}\x1b[0m")
     
     # Get XLIFF version from config (default: "1.2", supports "1.2" or "2.0")
-    xlf_version = config.get_setting("xlf.version", "1.2")
+    # Convert to string in case config returns a number
+    xlf_version_raw = config.get_setting("xlf.version", "1.2")
+    xlf_version = str(xlf_version_raw) if xlf_version_raw is not None else "1.2"
+    
+    # Validate version - must be "1.2" or "2.0"
     if xlf_version not in ["1.2", "2.0"]:
         if verbose:
-            click.echo(f"{Fore.YELLOW}Invalid XLIFF version '{xlf_version}', using default '1.2'\x1b[0m")
+            click.echo(f"{Fore.YELLOW}Invalid XLIFF version '{xlf_version}' in config, using default '1.2'\x1b[0m")
         xlf_version = "1.2"
+    if verbose:
+        click.echo(f"{Fore.BLUE}XLIFF version from config: {xlf_version} (will be overridden by file version if detected)\x1b[0m")
     
     # Get PO mark_fuzzy from config (default: false)
     po_mark_fuzzy = config.get_setting("po.mark_fuzzy", False)
@@ -225,11 +233,20 @@ def execute(language: Optional[str] = None, force: bool = False, only_missing: b
                     elif source_file.endswith((".xlf", ".xliff")):
                         # For XLIFF files, extract translatable strings to get a flat dictionary
                         source_content_raw = read_xliff_file(source_file)
+                        # Detect version from source file first (most authoritative)
+                        if source_content_raw and 'version' in source_content_raw:
+                            detected_source_version = source_content_raw['version']
+                            if verbose and detected_source_version != xlf_version:
+                                click.echo(f"  {Fore.CYAN}Source file has XLIFF version {detected_source_version}, overriding config version {xlf_version}\x1b[0m")
+                        
                         if os.path.exists(target_file):
                             target_content_raw = read_xliff_file(target_file)
                         else:
-                            # Create empty target with version from config
-                            target_content_raw = {'version': xlf_version, 'files': []}
+                            # Create empty target with version from source file (if available) or config
+                            target_version = source_content_raw.get('version', xlf_version) if source_content_raw else xlf_version
+                            target_content_raw = {'version': target_version, 'files': []}
+                            if verbose:
+                                click.echo(f"  {Fore.CYAN}Created new target file with XLIFF version {target_version}\x1b[0m")
                         source_content = extract_xliff_strings(source_content_raw)
                         target_content = extract_xliff_strings(target_content_raw)
                     else:
@@ -415,11 +432,20 @@ def execute(language: Optional[str] = None, force: bool = False, only_missing: b
                     elif source_file.endswith((".xlf", ".xliff")):
                         # For XLIFF files, extract translatable strings to get a flat dictionary
                         source_content_raw = read_xliff_file(source_file)
+                        # Detect version from source file first (most authoritative)
+                        if source_content_raw and 'version' in source_content_raw:
+                            detected_source_version = source_content_raw['version']
+                            if verbose and detected_source_version != xlf_version:
+                                click.echo(f"  {Fore.CYAN}Source file has XLIFF version {detected_source_version}, overriding config version {xlf_version}\x1b[0m")
+                        
                         if os.path.exists(target_file):
                             target_content_raw = read_xliff_file(target_file)
                         else:
-                            # Create empty target with version from config
-                            target_content_raw = {'version': xlf_version, 'files': []}
+                            # Create empty target with version from source file (if available) or config
+                            target_version = source_content_raw.get('version', xlf_version) if source_content_raw else xlf_version
+                            target_content_raw = {'version': target_version, 'files': []}
+                            if verbose:
+                                click.echo(f"  {Fore.CYAN}Created new target file with XLIFF version {target_version}\x1b[0m")
                         source_content = extract_xliff_strings(source_content_raw)
                         target_content = extract_xliff_strings(target_content_raw)
                     elif source_file.endswith((".csv", ".tsv")):
@@ -920,16 +946,49 @@ def execute(language: Optional[str] = None, force: bool = False, only_missing: b
                                 click.echo(f"  {Fore.YELLOW}XLIFF format does not support in-place updates yet, regenerating from scratch{Fore.RESET}")
                             # Update the original XLIFF structure with translations, preserving source text
                             # Also add new units from source that don't exist in target
-                            # Ensure version is set from config if target file doesn't exist
-                            if not target_content_raw or 'version' not in target_content_raw:
-                                if source_content_raw and 'version' in source_content_raw:
-                                    target_content_raw = {'version': source_content_raw['version'], 'files': []}
-                                else:
-                                    target_content_raw = {'version': xlf_version, 'files': []}
+                            # Ensure version is set - prefer source file version, then target file version, then config
+                            if not target_content_raw:
+                                target_content_raw = {}
+                            
+                            # Determine XLIFF version from source/target files or config
+                            detected_version = None
+                            if source_content_raw and 'version' in source_content_raw:
+                                detected_version = source_content_raw['version']
+                                if verbose:
+                                    click.echo(f"  {Fore.CYAN}Detected XLIFF version {detected_version} from source file\x1b[0m")
+                            elif target_content_raw and 'version' in target_content_raw:
+                                detected_version = target_content_raw['version']
+                                if verbose:
+                                    click.echo(f"  {Fore.CYAN}Detected XLIFF version {detected_version} from target file\x1b[0m")
+                            else:
+                                detected_version = xlf_version
+                                if verbose:
+                                    click.echo(f"  {Fore.CYAN}Using XLIFF version {detected_version} from config\x1b[0m")
+                            
+                            # Prefer source file version as authoritative, fallback to target file version, then config
+                            if source_content_raw and 'version' in source_content_raw:
+                                target_content_raw['version'] = source_content_raw['version']
+                            elif 'version' not in target_content_raw:
+                                target_content_raw['version'] = xlf_version
+                            
+                            if verbose:
+                                click.echo(f"  {Fore.CYAN}Applying target state '{xlf_target_state}' to XLIFF units\x1b[0m")
+                            
                             updated_content = update_xliff_targets(target_content_raw, translated_content, source_content_raw, xlf_target_state, only_missing=True)
-                            # Ensure version is set in updated content
+                            # Ensure version is set in updated content (update_xliff_targets should preserve it, but double-check)
                             if 'version' not in updated_content:
-                                updated_content['version'] = xlf_version
+                                # Fallback: prefer source version, then target version, then config
+                                if source_content_raw and 'version' in source_content_raw:
+                                    updated_content['version'] = source_content_raw['version']
+                                elif target_content_raw and 'version' in target_content_raw:
+                                    updated_content['version'] = target_content_raw['version']
+                                else:
+                                    updated_content['version'] = xlf_version
+                            
+                            final_version = updated_content.get('version', xlf_version)
+                            if verbose:
+                                click.echo(f"  {Fore.CYAN}Writing XLIFF file with version {final_version} and state '{xlf_target_state}'\x1b[0m")
+                            
                             write_xliff_file(target_file, updated_content, source_language, target_lang, xlf_target_state)
                         elif source_file.endswith((".csv", ".tsv")):
                             # mapped_target_lang is already defined above at line 843
@@ -1001,10 +1060,21 @@ def execute(language: Optional[str] = None, force: bool = False, only_missing: b
                         elif source_file.endswith(".html"):
                             write_html_file(target_file, source_file, translated_content)
                         elif source_file.endswith((".xlf", ".xliff")):
-                            # Ensure version is set from config
-                            if isinstance(translated_content, dict) and 'version' not in translated_content:
-                                translated_content['version'] = xlf_version
-                            write_xliff_file(target_file, translated_content, source_language, target_lang, xlf_target_state)
+                            # For XLIFF files, we need to use the structured format to properly add state
+                            # Read source file to get structure, then use update_xliff_targets
+                            source_content_raw = read_xliff_file(source_file)
+                            # Create empty target structure with version from source
+                            target_version = source_content_raw.get('version', xlf_version) if source_content_raw else xlf_version
+                            target_content_raw = {'version': target_version, 'files': []}
+                            if verbose:
+                                click.echo(f"  {Fore.CYAN}Creating new XLIFF file with version {target_version} and state '{xlf_target_state}'\x1b[0m")
+                            # Filter out any metadata keys (like 'version') from translated_content before processing
+                            # These shouldn't be treated as translation units
+                            filtered_translations = {k: v for k, v in translated_content.items() 
+                                                   if k != 'version' and isinstance(v, str)}
+                            # Use update_xliff_targets to properly structure the content and add state
+                            updated_content = update_xliff_targets(target_content_raw, filtered_translations, source_content_raw, xlf_target_state)
+                            write_xliff_file(target_file, updated_content, source_language, target_lang, xlf_target_state)
                         
                         click.echo(f"  {Fore.GREEN}✓ Saved to {target_file}\x1b[0m")
         

--- a/algebras/services/translator.py
+++ b/algebras/services/translator.py
@@ -151,6 +151,9 @@ class Translator:
         # Initialize custom prompt
         self.custom_prompt = ""
         
+        # Initialize verbose flag
+        self.verbose = False
+        
         # Shared rate limiting state for coordinating retries across parallel batches
         self._rate_limit_lock = threading.Lock()
         self._rate_limit_backoff_until = 0.0  # Timestamp until which we should back off
@@ -169,6 +172,15 @@ class Translator:
             prompt: Custom prompt text to use for translation
         """
         self.custom_prompt = prompt
+    
+    def set_verbose(self, verbose: bool) -> None:
+        """
+        Set verbose mode for detailed logging.
+        
+        Args:
+            verbose: Whether to enable verbose logging
+        """
+        self.verbose = verbose
     
     def _wait_for_rate_limit(self):
         """
@@ -861,6 +873,11 @@ class Translator:
             "flag": ui_safe
         }
         
+        if self.verbose:
+            print(f"  {Fore.CYAN}[API Request] Translating {len(non_empty_texts)} texts from {source_lang_value} to {target_lang}{Fore.RESET}")
+            if len(non_empty_texts) > 0:
+                print(f"  {Fore.CYAN}[API Request] Sample input: '{non_empty_texts[0][:50]}...'{Fore.RESET}")
+        
         try:
             # Use retry helper for 429 errors
             def make_api_call():
@@ -870,6 +887,9 @@ class Translator:
             
             if response.status_code == 200:
                 result = response.json()
+                
+                if self.verbose:
+                    print(f"  {Fore.CYAN}[API Response] Status: {response.status_code}{Fore.RESET}")
                 
                 # Handle the correct API response format
                 if "data" in result and "translations" in result["data"]:
@@ -882,15 +902,35 @@ class Translator:
                     # Fallback to old format if structure is different
                     translations = result.get("data", [])
                 
+                if self.verbose and len(translations) > 0:
+                    print(f"  {Fore.CYAN}[API Response] Sample output: '{translations[0][:50]}...'{Fore.RESET}")
+                    # Check if translation matches source (potential issue)
+                    if len(translations) > 0 and len(non_empty_texts) > 0:
+                        matches_source = sum(1 for i, trans in enumerate(translations) if trans == non_empty_texts[i])
+                        if matches_source > len(translations) * 0.5:
+                            print(f"  {Fore.YELLOW}[WARNING] {matches_source}/{len(translations)} translations match source text - API may not be translating{Fore.RESET}")
+                
                 # Ensure we have the same number of translations as non-empty input texts
                 if len(translations) != len(non_empty_texts):
                     raise Exception(f"Expected {len(non_empty_texts)} translations, but got {len(translations)}")
                 
-                # Apply normalization to each translation
+                # Apply normalization to each translation and validate
                 normalized_translations = []
+                empty_translation_count = 0
                 for i, translation in enumerate(translations):
                     normalized_translation = self.normalize_translation_string(non_empty_texts[i], translation)
                     normalized_translations.append(normalized_translation)
+                    
+                    # Check for empty or missing translations
+                    if not normalized_translation or normalized_translation.strip() == "":
+                        empty_translation_count += 1
+                        if self.verbose:
+                            print(f"  {Fore.YELLOW}[WARNING] Empty translation for: '{non_empty_texts[i][:50]}...'{Fore.RESET}")
+                
+                # Warn if many translations are empty
+                if empty_translation_count > 0:
+                    if self.verbose:
+                        print(f"  {Fore.YELLOW}[WARNING] {empty_translation_count}/{len(translations)} translations are empty{Fore.RESET}")
                 
                 # Reconstruct full result list with empty strings in correct positions
                 full_translations = []

--- a/algebras/utils/xliff_handler.py
+++ b/algebras/utils/xliff_handler.py
@@ -3,9 +3,12 @@ XLIFF (XML Localization Interchange File Format) file handler
 """
 
 import os
+import logging
 import xml.etree.ElementTree as ET
 from typing import Dict, Any, List, Optional
 from xml.dom import minidom
+
+logger = logging.getLogger(__name__)
 
 
 def read_xliff_file(file_path: str) -> Dict[str, Any]:
@@ -71,6 +74,8 @@ def write_xliff_file(file_path: str, content: Dict[str, Any],
         xmlns_attr = namespace
         version = '1.2'
     
+    logger.debug(f"Writing XLIFF file with version {version}, target_state={target_state}")
+    
     # Create XLIFF structure
     xliff_root = ET.Element('xliff')
     xliff_root.set('version', version)
@@ -111,7 +116,9 @@ def write_xliff_file(file_path: str, content: Dict[str, Any],
         container = body_elem
     
     # Handle different content structures
-    if 'files' in content and isinstance(content['files'], list) and content['files']:
+    # Check for structured format: must have 'files' key and it must be a list (even if empty)
+    # Empty list is valid - it means no units yet, but we still use structured format
+    if 'files' in content and isinstance(content['files'], list):
         # Use the first file's data
         file_data = content['files'][0]
         if 'trans-units' in file_data:
@@ -127,9 +134,11 @@ def write_xliff_file(file_path: str, content: Dict[str, Any],
                         target_elem = ET.SubElement(segment, 'target')
                         target_elem.text = unit.get('target', unit['source'])
                         # For XLIFF 2.0, state goes on segment, not target
-                        # Only add state if unit explicitly has one
-                        if 'state' in unit and unit['state']:
-                            segment.set('state', unit['state'])
+                        # Only add state if unit explicitly has one and it's not empty
+                        unit_state = unit.get('state')
+                        if unit_state and unit_state.strip():
+                            segment.set('state', unit_state)
+                            logger.debug(f"Added state '{unit_state}' to segment for unit {unit.get('id', 'unknown')} (XLIFF 2.0)")
                     else:
                         # XLIFF 1.2: use <trans-unit>
                         trans_unit = ET.SubElement(container, 'trans-unit')
@@ -139,12 +148,18 @@ def write_xliff_file(file_path: str, content: Dict[str, Any],
                         target_elem = ET.SubElement(trans_unit, 'target')
                         target_elem.text = unit.get('target', unit['source'])
                         # For XLIFF 1.2, state goes on target
-                        # Only add state if unit explicitly has one
-                        if 'state' in unit and unit['state']:
-                            target_elem.set('state', unit['state'])
+                        # Only add state if unit explicitly has one and it's not empty
+                        unit_state = unit.get('state')
+                        if unit_state and unit_state.strip():
+                            target_elem.set('state', unit_state)
+                            logger.debug(f"Added state '{unit_state}' to target for unit {unit.get('id', 'unknown')} (XLIFF 1.2)")
     else:
         # Handle flat dictionary structure (always write as XLIFF 1.2)
+        # Skip metadata keys like 'version' that shouldn't be translation units
+        metadata_keys = {'version'}
         for key, value in content.items():
+            if key in metadata_keys:
+                continue  # Skip metadata keys
             if isinstance(value, str):
                 trans_unit = ET.SubElement(container, 'trans-unit')
                 trans_unit.set('id', key)
@@ -152,7 +167,10 @@ def write_xliff_file(file_path: str, content: Dict[str, Any],
                 source_elem.text = value
                 target_elem = ET.SubElement(trans_unit, 'target')
                 target_elem.text = value
-                # Don't add state for flat dictionary structure - state should be set in update_xliff_targets
+                # Add state if target_state is provided (for flat dict structure from new file creation)
+                if target_state:
+                    target_elem.set('state', target_state)
+                    logger.debug(f"Added state '{target_state}' to target for unit {key} from flat dict (XLIFF 1.2)")
     
     # Write to file with proper formatting
     # Use ET.tostring with xml_declaration for better compatibility
@@ -259,8 +277,38 @@ def update_xliff_targets(xliff_content: Dict[str, Any], translations: Dict[str, 
     import copy
     updated_content = copy.deepcopy(xliff_content)
     
+    # Ensure version is preserved in updated content
+    # If version is missing, try to get it from source_content or original xliff_content
+    if 'version' not in updated_content:
+        if source_content and 'version' in source_content:
+            updated_content['version'] = source_content['version']
+            logger.debug(f"XLIFF version {source_content['version']} copied from source_content")
+        elif 'version' in xliff_content:
+            updated_content['version'] = xliff_content['version']
+            logger.debug(f"XLIFF version {xliff_content['version']} preserved from xliff_content")
+    else:
+        logger.debug(f"XLIFF version {updated_content['version']} already present in updated_content")
+    
+    final_version = updated_content.get('version', 'unknown')
+    logger.debug(f"Processing XLIFF with version {final_version}, target_state={target_state}, only_missing={only_missing}")
+    
     # Track which unit IDs already exist in target
     existing_unit_ids = set()
+    
+    # Ensure 'files' structure exists
+    if 'files' not in updated_content:
+        updated_content['files'] = []
+    
+    # If files list is empty, create a file entry from source_content if available
+    if not updated_content['files'] and source_content and 'files' in source_content and source_content['files']:
+        source_file_data = source_content['files'][0]
+        updated_content['files'].append({
+            'original': source_file_data.get('original', 'messages'),
+            'source-language': source_file_data.get('source-language', 'en'),
+            'target-language': source_file_data.get('target-language', 'en'),
+            'trans-units': []
+        })
+        logger.debug("Created file entry in updated_content from source_content")
     
     if 'files' in updated_content:
         for file_data in updated_content['files']:
@@ -282,14 +330,30 @@ def update_xliff_targets(xliff_content: Dict[str, Any], translations: Dict[str, 
                                 # Update target (either not only-missing mode, or target is empty)
                                 unit['target'] = translations[unit_id]
                             
-                            # For existing units, preserve existing state, don't set new state
-                            # State should only be set for new units from source
+                            # For existing units, preserve existing state if present
+                            # If no state exists and target_state is provided, add it
+                            # This applies even when preserving existing targets in only_missing mode
                             if existing_state:
                                 unit['state'] = existing_state
-                            # Don't set state for existing units, even if target was empty
+                                logger.debug(f"Preserved existing state '{existing_state}' for unit {unit_id}")
+                            elif target_state:
+                                # Add state to units that don't have one yet
+                                unit['state'] = target_state
+                                logger.debug(f"Added state '{target_state}' to existing unit {unit_id} (no previous state)")
                         elif 'source' in unit and not existing_target:
                             # If no translation provided but source exists and target is empty, use source as target
                             unit['target'] = unit['source']
+                            # Add state if provided and unit doesn't have one
+                            if not existing_state and target_state:
+                                unit['state'] = target_state
+                        
+                        # For ALL existing units (even if not in translations dict), add state if missing and target_state is provided
+                        # This ensures state is added to all units when using --only-missing or when file already has all translations
+                        # Check if state is missing or empty (empty string should be treated as missing)
+                        current_state = unit.get('state')
+                        if target_state and (not current_state or current_state.strip() == ''):
+                            unit['state'] = target_state
+                            logger.debug(f"Added state '{target_state}' to existing unit {unit_id} (unit not in translations dict or already had target)")
     
     # Add new units from source that don't exist in target
     if source_content and 'files' in source_content:
@@ -315,6 +379,7 @@ def update_xliff_targets(xliff_content: Dict[str, Any], translations: Dict[str, 
                             # Add state attribute if provided
                             if target_state:
                                 new_unit['state'] = target_state
+                                logger.debug(f"Added state '{target_state}' to new unit {source_unit_id} from source")
                             target_file_data['trans-units'].append(new_unit)
     
     return updated_content

--- a/algebras/utils/xliff_handler.py
+++ b/algebras/utils/xliff_handler.py
@@ -336,8 +336,10 @@ def update_xliff_targets(xliff_content: Dict[str, Any], translations: Dict[str, 
                                 unit['state'] = existing_state
                                 logger.debug(f"Preserved existing state '{existing_state}' for unit {unit_id}")
                         elif 'source' in unit and not existing_target:
-                            # If no translation provided but source exists and target is empty, use source as target
-                            unit['target'] = unit['source']
+                            # If no translation provided but source exists and target is empty
+                            # Leave target empty rather than copying source - this indicates missing translation
+                            logger.debug(f"No translation provided for existing unit {unit_id}, leaving target empty")
+                            unit['target'] = ''
                             # DO NOT add state to existing units
     
     # Add new units from source that don't exist in target
@@ -356,10 +358,16 @@ def update_xliff_targets(xliff_content: Dict[str, Any], translations: Dict[str, 
                         source_unit_id = source_unit.get('id')
                         if source_unit_id and source_unit_id not in existing_unit_ids:
                             # This is a new unit from source, add it to target
+                            # Check if we have a translation, otherwise use empty string (not source)
+                            target_value = translations.get(source_unit_id, '')
+                            if not target_value:
+                                # No translation provided - this is important to detect
+                                logger.warning(f"No translation provided for new unit {source_unit_id}, using empty target")
+                            
                             new_unit = {
                                 'id': source_unit_id,
                                 'source': source_unit.get('source', ''),
-                                'target': translations.get(source_unit_id, source_unit.get('source', ''))
+                                'target': target_value
                             }
                             # Add state attribute if provided
                             if target_state:

--- a/algebras/utils/xliff_handler.py
+++ b/algebras/utils/xliff_handler.py
@@ -331,29 +331,14 @@ def update_xliff_targets(xliff_content: Dict[str, Any], translations: Dict[str, 
                                 unit['target'] = translations[unit_id]
                             
                             # For existing units, preserve existing state if present
-                            # If no state exists and target_state is provided, add it
-                            # This applies even when preserving existing targets in only_missing mode
+                            # DO NOT add new state to existing units
                             if existing_state:
                                 unit['state'] = existing_state
                                 logger.debug(f"Preserved existing state '{existing_state}' for unit {unit_id}")
-                            elif target_state:
-                                # Add state to units that don't have one yet
-                                unit['state'] = target_state
-                                logger.debug(f"Added state '{target_state}' to existing unit {unit_id} (no previous state)")
                         elif 'source' in unit and not existing_target:
                             # If no translation provided but source exists and target is empty, use source as target
                             unit['target'] = unit['source']
-                            # Add state if provided and unit doesn't have one
-                            if not existing_state and target_state:
-                                unit['state'] = target_state
-                        
-                        # For ALL existing units (even if not in translations dict), add state if missing and target_state is provided
-                        # This ensures state is added to all units when using --only-missing or when file already has all translations
-                        # Check if state is missing or empty (empty string should be treated as missing)
-                        current_state = unit.get('state')
-                        if target_state and (not current_state or current_state.strip() == ''):
-                            unit['state'] = target_state
-                            logger.debug(f"Added state '{target_state}' to existing unit {unit_id} (unit not in translations dict or already had target)")
+                            # DO NOT add state to existing units
     
     # Add new units from source that don't exist in target
     if source_content and 'files' in source_content:

--- a/tests/commands/test_healthcheck_command.py
+++ b/tests/commands/test_healthcheck_command.py
@@ -437,7 +437,7 @@ class TestValidateFilePair:
         mock_issue_key1 = Issue('error', 'placeholders', 'Missing placeholder', 'key1')
         mock_issue_key2 = Issue('warning', 'formatting', 'Extra space', 'key2')
         
-        def validate_side_effect(source, target, key):
+        def validate_side_effect(source, target, key, is_xliff=False):
             if key == "key1":
                 return [mock_issue_key1]
             elif key == "key2":
@@ -474,7 +474,7 @@ class TestValidateFilePair:
         
         mock_issue_key1 = Issue('warning', 'formatting', 'Extra space', 'key1')
         
-        def validate_side_effect(source, target, key):
+        def validate_side_effect(source, target, key, is_xliff=False):
             if key == "key1":
                 return [mock_issue_key1]
             return []  # key2 has no issues
@@ -505,7 +505,7 @@ class TestValidateFilePair:
         
         mock_issue_key1 = Issue('error', 'placeholders', 'Missing placeholder', 'nested.key1')
         
-        def validate_side_effect(source, target, key):
+        def validate_side_effect(source, target, key, is_xliff=False):
             if key == "nested.key1":
                 return [mock_issue_key1]
             return []  # nested.key2 has no issues
@@ -639,7 +639,7 @@ class TestValidateFilePair:
         
         mock_config = MagicMock(spec=Config)
         
-        def validate_side_effect(source, target, key):
+        def validate_side_effect(source, target, key, is_xliff=False):
             if key == "key1":
                 return [error_issue]
             elif key == "key2":

--- a/tests/test_xliff_config_prompt.py
+++ b/tests/test_xliff_config_prompt.py
@@ -1,0 +1,215 @@
+"""
+Tests for XLIFF config prompt support with --only-missing flag.
+
+This test suite verifies that:
+- Prompt from config file works with --only-missing flag
+- --prompt-file takes precedence over config prompt
+- Prompt is passed to translate_missing_keys_batch
+"""
+
+import os
+import tempfile
+from unittest.mock import patch, MagicMock, mock_open
+import pytest
+
+from algebras.config import Config
+from algebras.services.translator import Translator
+from algebras.commands.translate_command import execute
+
+
+class TestXLIFFConfigPrompt:
+    """Test cases for config prompt support with --only-missing."""
+    
+    def test_config_prompt_works_with_only_missing(self, monkeypatch):
+        """
+        Test that prompt from config file works with --only-missing flag.
+        
+        Behavior: When a prompt is configured in the config file and --only-missing
+        is used, the prompt should be loaded and passed to the translator for
+        batch translation of missing keys.
+        """
+        # Mock config with prompt
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.load.return_value = {}
+        mock_config.get_source_language.return_value = "en"
+        mock_config.get_languages.return_value = ["en", "fr"]
+        mock_config.get_source_files.return_value = {}
+        mock_config.get_setting.side_effect = lambda key, default=None: {
+            "api.prompt": "Add HELLO at the end of each string",
+            "xlf.default_target_state": "translated"
+        }.get(key, default)
+        mock_config.get_destination_locale_code.return_value = "fr"
+        
+        # Mock file scanner
+        mock_scanner = MagicMock()
+        mock_scanner.scan.return_value = {}
+        
+        # Mock translator
+        mock_translator = MagicMock()
+        mock_translator.translate_missing_keys_batch.return_value = {"key1": "Bonjour"}
+        
+        with patch("algebras.commands.translate_command.Config", return_value=mock_config), \
+             patch("algebras.commands.translate_command.FileScanner", return_value=mock_scanner), \
+             patch("algebras.commands.translate_command.Translator", return_value=mock_translator), \
+             patch("algebras.commands.translate_command.validate_language_files", return_value=(True, {"key1"})), \
+             patch("algebras.commands.translate_command.read_xliff_file") as mock_read, \
+             patch("algebras.commands.translate_command.extract_xliff_strings") as mock_extract, \
+             patch("algebras.commands.translate_command.update_xliff_targets") as mock_update, \
+             patch("algebras.commands.translate_command.write_xliff_file") as mock_write, \
+             patch("os.path.exists", return_value=True), \
+             patch("os.makedirs"):
+            
+            # Setup mocks
+            mock_read.return_value = {
+                'version': '1.2',
+                'files': [{'trans-units': [{'id': 'key1', 'source': 'Hello', 'target': ''}]}]
+            }
+            mock_extract.side_effect = lambda x: {'key1': 'Hello'} if x else {}
+            mock_update.return_value = {
+                'version': '1.2',
+                'files': [{'trans-units': [{'id': 'key1', 'source': 'Hello', 'target': 'Bonjour'}]}]
+            }
+            
+            # Create temp files
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as source_f, \
+                 tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as target_f:
+                source_file = source_f.name
+                target_file = target_f.name
+            
+            try:
+                # Mock file paths
+                with patch("algebras.commands.translate_command.resolve_destination_path", return_value=target_file):
+                    # Execute with --only-missing
+                    execute(language="fr", only_missing=True, config_file=None)
+                    
+                    # Verify set_custom_prompt was called with config prompt
+                    assert mock_translator.set_custom_prompt.called
+                    call_args = mock_translator.set_custom_prompt.call_args[0][0]
+                    assert "HELLO" in call_args or "hello" in call_args.lower()
+                    
+                    # Verify translate_missing_keys_batch was called
+                    assert mock_translator.translate_missing_keys_batch.called
+            finally:
+                if os.path.exists(source_file):
+                    os.unlink(source_file)
+                if os.path.exists(target_file):
+                    os.unlink(target_file)
+    
+    def test_prompt_file_takes_precedence_over_config(self, monkeypatch):
+        """
+        Test that --prompt-file takes precedence over config prompt.
+        
+        Behavior: When both --prompt-file and config prompt are provided,
+        the --prompt-file prompt should be used, not the config prompt.
+        """
+        # Mock config with prompt
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.load.return_value = {}
+        mock_config.get_source_language.return_value = "en"
+        mock_config.get_languages.return_value = ["en", "fr"]
+        mock_config.get_source_files.return_value = {}
+        mock_config.get_setting.side_effect = lambda key, default=None: {
+            "api.prompt": "Config prompt",
+            "xlf.default_target_state": "translated"
+        }.get(key, default)
+        mock_config.get_destination_locale_code.return_value = "fr"
+        
+        # Mock file scanner
+        mock_scanner = MagicMock()
+        mock_scanner.scan.return_value = {}
+        
+        # Mock translator
+        mock_translator = MagicMock()
+        mock_translator.translate_missing_keys_batch.return_value = {"key1": "Bonjour"}
+        
+        # Create prompt file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as prompt_f:
+            prompt_file = prompt_f.name
+            prompt_f.write("File prompt - Add HELLO")
+        
+        try:
+            with patch("algebras.commands.translate_command.Config", return_value=mock_config), \
+                 patch("algebras.commands.translate_command.FileScanner", return_value=mock_scanner), \
+                 patch("algebras.commands.translate_command.Translator", return_value=mock_translator), \
+                 patch("algebras.commands.translate_command.validate_language_files", return_value=(True, {"key1"})), \
+                 patch("algebras.commands.translate_command.read_xliff_file") as mock_read, \
+                 patch("algebras.commands.translate_command.extract_xliff_strings") as mock_extract, \
+                 patch("algebras.commands.translate_command.update_xliff_targets") as mock_update, \
+                 patch("algebras.commands.translate_command.write_xliff_file") as mock_write, \
+                 patch("os.path.exists", return_value=True), \
+                 patch("os.makedirs"):
+                
+                # Setup mocks
+                mock_read.return_value = {
+                    'version': '1.2',
+                    'files': [{'trans-units': [{'id': 'key1', 'source': 'Hello', 'target': ''}]}]
+                }
+                mock_extract.side_effect = lambda x: {'key1': 'Hello'} if x else {}
+                mock_update.return_value = {
+                    'version': '1.2',
+                    'files': [{'trans-units': [{'id': 'key1', 'source': 'Hello', 'target': 'Bonjour'}]}]
+                }
+                
+                # Create temp files
+                with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as source_f, \
+                     tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as target_f:
+                    source_file = source_f.name
+                    target_file = target_f.name
+                
+                try:
+                    # Mock file paths
+                    with patch("algebras.commands.translate_command.resolve_destination_path", return_value=target_file):
+                        # Execute with --only-missing and --prompt-file
+                        execute(language="fr", only_missing=True, prompt_file=prompt_file, config_file=None)
+                        
+                        # Verify set_custom_prompt was called with file prompt, not config prompt
+                        assert mock_translator.set_custom_prompt.called
+                        call_args = mock_translator.set_custom_prompt.call_args[0][0]
+                        assert "File prompt" in call_args
+                        assert "Config prompt" not in call_args
+                finally:
+                    if os.path.exists(source_file):
+                        os.unlink(source_file)
+                    if os.path.exists(target_file):
+                        os.unlink(target_file)
+        finally:
+            if os.path.exists(prompt_file):
+                os.unlink(prompt_file)
+    
+    def test_prompt_passed_to_translate_missing_keys_batch(self, monkeypatch):
+        """
+        Test that prompt is passed to translate_missing_keys_batch.
+        
+        Behavior: When a prompt is set (either from config or file), it should be
+        available in the translator when translate_missing_keys_batch is called,
+        so the API can use it for translation.
+        """
+        # Mock config
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.load.return_value = {}
+        mock_config.get_source_language.return_value = "en"
+        mock_config.get_languages.return_value = ["en", "fr"]
+        mock_config.get_source_files.return_value = {}
+        mock_config.get_setting.side_effect = lambda key, default=None: {
+            "api.prompt": "Custom prompt",
+            "xlf.default_target_state": "translated"
+        }.get(key, default)
+        mock_config.get_destination_locale_code.return_value = "fr"
+        
+        # Create real translator instance to test prompt propagation
+        with patch("algebras.services.translator.Config", return_value=mock_config), \
+             patch.dict(os.environ, {"ALGEBRAS_API_KEY": "test-key"}):
+            
+            translator = Translator(config=mock_config)
+            translator.set_custom_prompt("Test prompt")
+            
+            # Verify prompt is stored
+            assert translator.custom_prompt == "Test prompt"
+            
+            # When translate_missing_keys_batch calls _translate_with_algebras_ai_batch,
+            # the prompt should be available in custom_prompt attribute
+            # This is tested indirectly by checking the attribute exists
+

--- a/tests/test_xliff_handler.py
+++ b/tests/test_xliff_handler.py
@@ -627,10 +627,11 @@ class TestXLIFFHandler:
             write_xliff_file(temp_file, xliff_content, "en", "es", "translated")
             
             # Read it back and verify state attribute is present
+            # For XLIFF 2.0, state goes on segment, not target
             with open(temp_file, 'r', encoding='utf-8') as f:
                 content = f.read()
                 assert 'state="needs-review-translation"' in content
-                assert '<target state="needs-review-translation">Hola</target>' in content
+                assert '<segment state="needs-review-translation">' in content
         finally:
             os.unlink(temp_file)
 

--- a/tests/test_xliff_handler.py
+++ b/tests/test_xliff_handler.py
@@ -525,9 +525,10 @@ class TestXLIFFHandler:
         
         result = update_xliff_targets(xliff_content, translations)
         
-        # Should use source as target if no translation and target is empty
+        # Should keep target empty (not use source) when no translation provided
+        # This makes missing translations more visible
         assert result['files'][0]['trans-units'][0]['source'] == 'Hello'
-        assert result['files'][0]['trans-units'][0]['target'] == 'Hello'
+        assert result['files'][0]['trans-units'][0]['target'] == ''
 
     def test_update_xliff_targets_adds_missing_units_from_source(self):
         """Test that update_xliff_targets adds new units from source that don't exist in target."""

--- a/tests/test_xliff_only_missing_preservation.py
+++ b/tests/test_xliff_only_missing_preservation.py
@@ -174,7 +174,7 @@ class TestXLIFFOnlyMissingPreservation:
             'key2': 'Monde'   # Should be added (missing)
         }
         
-        updated = update_xliff_targets(target_content, translations, source_content)
+        updated = update_xliff_targets(target_content, translations, source_content, only_missing=True)
         
         # Verify key1 was NOT overwritten
         key1_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key1'), None)

--- a/tests/test_xliff_only_missing_preservation.py
+++ b/tests/test_xliff_only_missing_preservation.py
@@ -1,0 +1,232 @@
+"""
+Tests for XLIFF --only-missing flag preserving existing translations.
+
+This test suite verifies that when using --only-missing flag:
+- Existing translations in target files are preserved
+- Second run with --only-missing doesn't overwrite existing translations
+- Only missing keys are translated and added
+"""
+
+import os
+import tempfile
+import pytest
+from algebras.utils.xliff_handler import (
+    read_xliff_file, write_xliff_file, update_xliff_targets, extract_translatable_strings
+)
+
+
+class TestXLIFFOnlyMissingPreservation:
+    """Test cases for --only-missing flag preserving existing translations."""
+    
+    def test_only_missing_preserves_existing_translations(self):
+        """
+        Test that --only-missing preserves existing translations when target file exists.
+        
+        Behavior: When updating a target file with --only-missing, existing target values
+        should remain unchanged, and only missing keys should be added with translations.
+        """
+        # Create source XLIFF with 3 units
+        source_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': ''},
+                    {'id': 'key2', 'source': 'World', 'target': ''},
+                    {'id': 'key3', 'source': 'Test', 'target': ''}
+                ]
+            }]
+        }
+        
+        # Create target XLIFF with 2 existing translations
+        target_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': 'Bonjour'},  # Existing translation
+                    {'id': 'key2', 'source': 'World', 'target': 'Monde'}  # Existing translation
+                    # key3 is missing
+                ]
+            }]
+        }
+        
+        # Simulate translation of only missing keys (key3)
+        translations = {'key3': 'Teste'}  # Only translate missing key
+        
+        # Update targets
+        updated = update_xliff_targets(target_content, translations, source_content)
+        
+        # Verify existing translations are preserved
+        assert len(updated['files'][0]['trans-units']) == 3
+        
+        key1_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key1'), None)
+        assert key1_unit is not None
+        assert key1_unit['target'] == 'Bonjour'  # Preserved
+        
+        key2_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key2'), None)
+        assert key2_unit is not None
+        assert key2_unit['target'] == 'Monde'  # Preserved
+        
+        # Verify missing key was added
+        key3_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key3'), None)
+        assert key3_unit is not None
+        assert key3_unit['target'] == 'Teste'  # Newly translated
+    
+    def test_second_run_doesnt_overwrite_existing_translations(self):
+        """
+        Test that second run with --only-missing doesn't overwrite existing translations.
+        
+        Behavior: When running --only-missing twice, the second run should not replace
+        existing translations with untranslated values. It should only add truly missing keys.
+        """
+        # Initial target file with some translations
+        target_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': 'Bonjour'},
+                    {'id': 'key2', 'source': 'World', 'target': 'Monde'}
+                ]
+            }]
+        }
+        
+        # Source content
+        source_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': ''},
+                    {'id': 'key2', 'source': 'World', 'target': ''},
+                    {'id': 'key3', 'source': 'Test', 'target': ''}
+                ]
+            }]
+        }
+        
+        # First run: translate missing key3
+        translations_run1 = {'key3': 'Teste'}
+        updated_run1 = update_xliff_targets(target_content, translations_run1, source_content)
+        
+        # Verify existing translations preserved
+        key1_unit = next((u for u in updated_run1['files'][0]['trans-units'] if u['id'] == 'key1'), None)
+        assert key1_unit['target'] == 'Bonjour'
+        
+        # Second run: simulate running again with same missing keys (should be empty now)
+        # But if somehow key1 or key2 are in translations dict, they should NOT overwrite
+        translations_run2 = {}  # No missing keys
+        updated_run2 = update_xliff_targets(updated_run1, translations_run2, source_content)
+        
+        # Verify existing translations still preserved
+        key1_unit_run2 = next((u for u in updated_run2['files'][0]['trans-units'] if u['id'] == 'key1'), None)
+        assert key1_unit_run2['target'] == 'Bonjour'  # Still preserved
+        
+        key2_unit_run2 = next((u for u in updated_run2['files'][0]['trans-units'] if u['id'] == 'key2'), None)
+        assert key2_unit_run2['target'] == 'Monde'  # Still preserved
+    
+    def test_only_missing_keys_are_translated(self):
+        """
+        Test that only missing keys are translated and added.
+        
+        Behavior: When using --only-missing, the update_xliff_targets function should
+        only update targets for keys that are in the translations dictionary and were
+        missing from the target file. Keys already present should be left unchanged.
+        """
+        # Target with one existing translation
+        target_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': 'Bonjour'}  # Already translated
+                ]
+            }]
+        }
+        
+        # Source with two keys
+        source_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': ''},
+                    {'id': 'key2', 'source': 'World', 'target': ''}  # Missing
+                ]
+            }]
+        }
+        
+        # Translations dict contains both keys, but only key2 should be updated
+        translations = {
+            'key1': 'Salut',  # Should be ignored (already exists)
+            'key2': 'Monde'   # Should be added (missing)
+        }
+        
+        updated = update_xliff_targets(target_content, translations, source_content)
+        
+        # Verify key1 was NOT overwritten
+        key1_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key1'), None)
+        assert key1_unit['target'] == 'Bonjour'  # Original preserved, not 'Salut'
+        
+        # Verify key2 was added
+        key2_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key2'), None)
+        assert key2_unit is not None
+        assert key2_unit['target'] == 'Monde'
+    
+    def test_update_xliff_targets_preserves_existing_when_translation_missing(self):
+        """
+        Test that update_xliff_targets preserves existing targets when translation is not provided.
+        
+        Behavior: If a unit exists in target but is not in the translations dictionary,
+        its existing target value should be preserved, not replaced with source or empty.
+        """
+        target_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': 'Bonjour'}  # Existing
+                ]
+            }]
+        }
+        
+        source_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': ''},
+                    {'id': 'key2', 'source': 'World', 'target': ''}
+                ]
+            }]
+        }
+        
+        # Only translate key2, not key1
+        translations = {'key2': 'Monde'}
+        
+        updated = update_xliff_targets(target_content, translations, source_content)
+        
+        # Verify key1 target is preserved
+        key1_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key1'), None)
+        assert key1_unit['target'] == 'Bonjour'  # Preserved, not replaced
+        
+        # Verify key2 was added
+        key2_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key2'), None)
+        assert key2_unit['target'] == 'Monde'
+

--- a/tests/test_xliff_ph_tag_extraction.py
+++ b/tests/test_xliff_ph_tag_extraction.py
@@ -1,0 +1,263 @@
+"""
+Tests for XLIFF ph tag and child element extraction.
+
+This test suite verifies that source text extraction includes all child elements
+(ph, pc, sc, ec, mrk) and preserves XML structure when extracting source text.
+"""
+
+import os
+import tempfile
+import pytest
+from algebras.utils.xliff_handler import read_xliff_file, extract_translatable_strings
+
+
+class TestXLIFFPhTagExtraction:
+    """Test cases for extracting full text including ph tags and other child elements."""
+    
+    def test_extract_source_with_ph_tag_xliff_12(self):
+        """
+        Test that source text extraction includes ph tags in XLIFF 1.2 format.
+        
+        Behavior: When extracting source text from XLIFF 1.2 files, the full text
+        including all child elements like <ph> should be extracted, not just the
+        direct text content before the first tag.
+        """
+        xliff_content = '''<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="messages" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="welcome">
+        <source>Hello <ph id="1" equiv-text="%name"/>!</source>
+        <target></target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>'''
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            f.write(xliff_content)
+            temp_file = f.name
+        
+        try:
+            result = read_xliff_file(temp_file)
+            translatable = extract_translatable_strings(result)
+            
+            # Verify full text including ph tag is extracted
+            assert 'welcome' in translatable
+            # The text should include the ph tag content
+            # Exact format depends on implementation, but should not be truncated
+            source_text = translatable['welcome']
+            assert 'Hello' in source_text
+            assert 'ph' in source_text or '%name' in source_text or '1' in source_text
+        finally:
+            os.unlink(temp_file)
+    
+    def test_extract_source_with_ph_tag_xliff_20(self):
+        """
+        Test that source text extraction includes ph tags in XLIFF 2.0 format.
+        
+        Behavior: When extracting source text from XLIFF 2.0 files, the full text
+        including all child elements like <ph> should be extracted from within <segment>.
+        """
+        xliff_content = '''<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+  <file id="f1" original="messages">
+    <unit id="welcome">
+      <segment>
+        <source>Hello <ph id="1" equiv-text="%name"/>!</source>
+        <target></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>'''
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            f.write(xliff_content)
+            temp_file = f.name
+        
+        try:
+            result = read_xliff_file(temp_file)
+            translatable = extract_translatable_strings(result)
+            
+            # Verify full text including ph tag is extracted
+            assert 'welcome' in translatable
+            source_text = translatable['welcome']
+            assert 'Hello' in source_text
+            assert 'ph' in source_text or '%name' in source_text or '1' in source_text
+        finally:
+            os.unlink(temp_file)
+    
+    def test_extract_source_with_multiple_ph_tags(self):
+        """
+        Test that source text extraction includes multiple ph tags.
+        
+        Behavior: When a source contains multiple <ph> tags, all of them should be
+        included in the extracted text, not just the first one.
+        """
+        xliff_content = '''<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="messages" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="message">
+        <source>Hello <ph id="1" equiv-text="%name"/>, you have <ph id="2" equiv-text="%count"/> messages.</source>
+        <target></target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>'''
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            f.write(xliff_content)
+            temp_file = f.name
+        
+        try:
+            result = read_xliff_file(temp_file)
+            translatable = extract_translatable_strings(result)
+            
+            source_text = translatable['message']
+            # Should contain both ph tags
+            assert 'Hello' in source_text
+            assert 'you have' in source_text or 'messages' in source_text
+            # Should not be truncated at first ph tag
+            assert len(source_text) > len('Hello')
+        finally:
+            os.unlink(temp_file)
+    
+    def test_extract_source_with_pc_tags(self):
+        """
+        Test that source text extraction includes pc (paired code) tags.
+        
+        Behavior: XLIFF 2.0 uses <pc> tags for paired codes (like bold, italic).
+        These should be included in the extracted text.
+        """
+        xliff_content = '''<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+  <file id="f1" original="messages">
+    <unit id="bold">
+      <segment>
+        <source>This is <pc id="1" type="fmt">bold</pc> text.</source>
+        <target></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>'''
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            f.write(xliff_content)
+            temp_file = f.name
+        
+        try:
+            result = read_xliff_file(temp_file)
+            translatable = extract_translatable_strings(result)
+            
+            source_text = translatable['bold']
+            assert 'This is' in source_text
+            assert 'bold' in source_text
+            assert 'text' in source_text
+        finally:
+            os.unlink(temp_file)
+    
+    def test_extract_source_with_sc_ec_tags(self):
+        """
+        Test that source text extraction includes sc (start code) and ec (end code) tags.
+        
+        Behavior: XLIFF 1.2 uses <sc> and <ec> tags for start/end codes.
+        These should be included in the extracted text.
+        """
+        xliff_content = '''<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="messages" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="formatted">
+        <source>This is <sc id="1" type="bold"/>bold<ec id="1"/> text.</source>
+        <target></target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>'''
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            f.write(xliff_content)
+            temp_file = f.name
+        
+        try:
+            result = read_xliff_file(temp_file)
+            translatable = extract_translatable_strings(result)
+            
+            source_text = translatable['formatted']
+            assert 'This is' in source_text
+            assert 'bold' in source_text
+            assert 'text' in source_text
+        finally:
+            os.unlink(temp_file)
+    
+    def test_extract_source_with_mrk_tags(self):
+        """
+        Test that source text extraction includes mrk (marker) tags.
+        
+        Behavior: <mrk> tags are used for markers in XLIFF. These should be
+        included in the extracted text.
+        """
+        xliff_content = '''<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en" trgLang="fr">
+  <file id="f1" original="messages">
+    <unit id="marked">
+      <segment>
+        <source>This is <mrk id="m1" type="term">terminology</mrk> text.</source>
+        <target></target>
+      </segment>
+    </unit>
+  </file>
+</xliff>'''
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            f.write(xliff_content)
+            temp_file = f.name
+        
+        try:
+            result = read_xliff_file(temp_file)
+            translatable = extract_translatable_strings(result)
+            
+            source_text = translatable['marked']
+            assert 'This is' in source_text
+            assert 'terminology' in source_text
+            assert 'text' in source_text
+        finally:
+            os.unlink(temp_file)
+    
+    def test_extract_source_preserves_xml_structure(self):
+        """
+        Test that source text extraction preserves XML structure of child elements.
+        
+        Behavior: When extracting text with child elements, the structure should be
+        preserved in a way that allows proper translation and reconstruction.
+        """
+        xliff_content = '''<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="messages" source-language="en" target-language="fr" datatype="plaintext">
+    <body>
+      <trans-unit id="complex">
+        <source>Click <ph id="1" equiv-text="%link"/> to <ph id="2" equiv-text="%action"/>.</source>
+        <target></target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>'''
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            f.write(xliff_content)
+            temp_file = f.name
+        
+        try:
+            result = read_xliff_file(temp_file)
+            translatable = extract_translatable_strings(result)
+            
+            source_text = translatable['complex']
+            # Should contain the full message, not truncated
+            assert 'Click' in source_text
+            assert 'to' in source_text
+            # Should include both placeholders
+            assert len(source_text) > len('Click')
+        finally:
+            os.unlink(temp_file)
+

--- a/tests/test_xliff_placeholder_detection.py
+++ b/tests/test_xliff_placeholder_detection.py
@@ -1,0 +1,163 @@
+"""
+Tests for XLIFF placeholder detection in healthcheck command.
+
+This test suite verifies that healthcheck detects XLIFF-specific placeholders
+(ph, pc, sc, ec, mrk) and reports missing/extra placeholders as errors/warnings.
+"""
+
+import os
+import tempfile
+import pytest
+from algebras.utils.translation_validator import extract_xliff_placeholders, check_xliff_placeholders, Issue
+
+
+class TestXLIFFPlaceholderDetection:
+    """Test cases for XLIFF placeholder detection in healthcheck."""
+    
+    def test_extract_ph_tags(self):
+        """
+        Test that extract_xliff_placeholders detects ph (placeholder) tags.
+        
+        Behavior: The function should extract all <ph> tags from XLIFF source/target text,
+        including their attributes like id and equiv-text.
+        """
+        source_text = 'Hello <ph id="1" equiv-text="%name"/>!'
+        placeholders = extract_xliff_placeholders(source_text)
+        
+        assert len(placeholders) > 0
+        # Should detect ph tag
+        assert any('ph' in str(p) or '1' in str(p) or '%name' in str(p) for p in placeholders)
+    
+    def test_extract_pc_tags(self):
+        """
+        Test that extract_xliff_placeholders detects pc (paired code) tags.
+        
+        Behavior: The function should extract <pc> tags used in XLIFF 2.0 for
+        paired formatting codes like bold, italic.
+        """
+        source_text = 'This is <pc id="1" type="fmt">bold</pc> text.'
+        placeholders = extract_xliff_placeholders(source_text)
+        
+        assert len(placeholders) > 0
+        # Should detect pc tag
+        assert any('pc' in str(p) or '1' in str(p) for p in placeholders)
+    
+    def test_extract_sc_ec_tags(self):
+        """
+        Test that extract_xliff_placeholders detects sc (start code) and ec (end code) tags.
+        
+        Behavior: The function should extract <sc> and <ec> tag pairs used in XLIFF 1.2
+        for formatting codes.
+        """
+        source_text = 'This is <sc id="1" type="bold"/>bold<ec id="1"/> text.'
+        placeholders = extract_xliff_placeholders(source_text)
+        
+        assert len(placeholders) > 0
+        # Should detect sc and ec tags
+        assert any('sc' in str(p) or 'ec' in str(p) or '1' in str(p) for p in placeholders)
+    
+    def test_extract_mrk_tags(self):
+        """
+        Test that extract_xliff_placeholders detects mrk (marker) tags.
+        
+        Behavior: The function should extract <mrk> tags used for markers in XLIFF.
+        """
+        source_text = 'This is <mrk id="m1" type="term">terminology</mrk> text.'
+        placeholders = extract_xliff_placeholders(source_text)
+        
+        assert len(placeholders) > 0
+        # Should detect mrk tag
+        assert any('mrk' in str(p) or 'm1' in str(p) for p in placeholders)
+    
+    def test_check_xliff_placeholders_missing_placeholder(self):
+        """
+        Test that check_xliff_placeholders reports missing placeholders as errors.
+        
+        Behavior: When a placeholder exists in source but not in target, it should
+        be reported as an error.
+        """
+        source = 'Hello <ph id="1" equiv-text="%name"/>!'
+        target = 'Bonjour!'  # Missing ph tag
+        
+        issues = check_xliff_placeholders(source, target, key="test.key")
+        
+        # Should have at least one error
+        errors = [i for i in issues if i.severity == 'error']
+        assert len(errors) > 0
+        assert any('placeholder' in i.message.lower() or 'ph' in i.message.lower() for i in errors)
+    
+    def test_check_xliff_placeholders_extra_placeholder(self):
+        """
+        Test that check_xliff_placeholders reports extra placeholders as warnings.
+        
+        Behavior: When a placeholder exists in target but not in source, it should
+        be reported as a warning.
+        """
+        source = 'Hello!'
+        target = 'Bonjour <ph id="1" equiv-text="%name"/>!'  # Extra ph tag
+        
+        issues = check_xliff_placeholders(source, target, key="test.key")
+        
+        # Should have at least one warning
+        warnings = [i for i in issues if i.severity == 'warning']
+        assert len(warnings) > 0
+        assert any('extra' in i.message.lower() or 'placeholder' in i.message.lower() for i in warnings)
+    
+    def test_check_xliff_placeholders_matching_placeholders(self):
+        """
+        Test that check_xliff_placeholders passes when placeholders match.
+        
+        Behavior: When source and target have matching placeholders, no issues
+        should be reported.
+        """
+        source = 'Hello <ph id="1" equiv-text="%name"/>!'
+        target = 'Bonjour <ph id="1" equiv-text="%name"/>!'
+        
+        issues = check_xliff_placeholders(source, target, key="test.key")
+        
+        # Should have no errors
+        errors = [i for i in issues if i.severity == 'error']
+        assert len(errors) == 0
+    
+    def test_check_xliff_placeholders_multiple_placeholders(self):
+        """
+        Test that check_xliff_placeholders handles multiple placeholders correctly.
+        
+        Behavior: When source has multiple placeholders, all should be checked
+        and missing ones reported.
+        """
+        source = 'Hello <ph id="1" equiv-text="%name"/>, you have <ph id="2" equiv-text="%count"/> messages.'
+        target = 'Bonjour <ph id="1" equiv-text="%name"/>!'  # Missing second ph tag
+        
+        issues = check_xliff_placeholders(source, target, key="test.key")
+        
+        # Should have error for missing placeholder
+        errors = [i for i in issues if i.severity == 'error']
+        assert len(errors) > 0
+    
+    def test_check_xliff_placeholders_different_placeholder_ids(self):
+        """
+        Test that check_xliff_placeholders detects when placeholder IDs don't match.
+        
+        Behavior: When source and target have placeholders with different IDs,
+        this should be reported as an issue.
+        """
+        source = 'Hello <ph id="1" equiv-text="%name"/>!'
+        target = 'Bonjour <ph id="2" equiv-text="%name"/>!'  # Different ID
+        
+        issues = check_xliff_placeholders(source, target, key="test.key")
+        
+        # Should detect mismatch (either as missing or extra)
+        assert len(issues) > 0
+    
+    def test_healthcheck_calls_xliff_placeholder_check(self):
+        """
+        Test that healthcheck command calls XLIFF placeholder validation.
+        
+        Behavior: When healthcheck validates XLIFF files, it should call
+        check_xliff_placeholders for source/target pairs.
+        """
+        # This test would verify integration with healthcheck_command
+        # The actual implementation will be tested in healthcheck_command tests
+        pass
+

--- a/tests/test_xliff_state_attribute.py
+++ b/tests/test_xliff_state_attribute.py
@@ -1,0 +1,262 @@
+"""
+Tests for XLIFF state attribute placement and configuration.
+
+This test suite verifies that:
+- State attribute is placed on <target> for XLIFF 1.2
+- State attribute is placed on <segment> for XLIFF 2.0
+- State attribute is added to newly translated targets
+- State attribute respects XLIFF version from config
+"""
+
+import os
+import tempfile
+import xml.etree.ElementTree as ET
+import pytest
+from algebras.utils.xliff_handler import write_xliff_file, update_xliff_targets, read_xliff_file
+
+
+class TestXLIFFStateAttribute:
+    """Test cases for XLIFF state attribute placement."""
+    
+    def test_state_attribute_on_target_xliff_12(self):
+        """
+        Test that state attribute is placed on <target> element for XLIFF 1.2.
+        
+        Behavior: When writing XLIFF 1.2 files, the state attribute should be
+        placed on the <target> element, not on <segment> or <trans-unit>.
+        """
+        xliff_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {
+                        'id': 'key1',
+                        'source': 'Hello',
+                        'target': 'Bonjour',
+                        'state': 'translated'
+                    }
+                ]
+            }]
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            temp_file = f.name
+        
+        try:
+            write_xliff_file(temp_file, xliff_content, "en", "fr", "translated")
+            
+            # Read back and verify state is on target
+            tree = ET.parse(temp_file)
+            root = tree.getroot()
+            
+            # Find target element
+            namespace = 'urn:oasis:names:tc:xliff:document:1.2'
+            target_elem = root.find(f'.//{{{namespace}}}target') or root.find('.//target')
+            
+            assert target_elem is not None
+            assert target_elem.get('state') == 'translated'
+            
+            # Verify state is NOT on segment (XLIFF 1.2 doesn't have segment)
+            segment_elem = root.find(f'.//{{{namespace}}}segment') or root.find('.//segment')
+            assert segment_elem is None  # XLIFF 1.2 doesn't use segment
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+    
+    def test_state_attribute_on_segment_xliff_20(self):
+        """
+        Test that state attribute is placed on <segment> element for XLIFF 2.0.
+        
+        Behavior: When writing XLIFF 2.0 files, the state attribute should be
+        placed on the <segment> element, not on <target>.
+        """
+        xliff_content = {
+            'version': '2.0',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {
+                        'id': 'key1',
+                        'source': 'Hello',
+                        'target': 'Bonjour',
+                        'state': 'translated'
+                    }
+                ]
+            }]
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            temp_file = f.name
+        
+        try:
+            write_xliff_file(temp_file, xliff_content, "en", "fr", "translated")
+            
+            # Read back and verify state is on segment
+            tree = ET.parse(temp_file)
+            root = tree.getroot()
+            
+            # Find segment element
+            namespace = 'urn:oasis:names:tc:xliff:document:2.0'
+            segment_elem = root.find(f'.//{{{namespace}}}segment') or root.find('.//segment')
+            
+            assert segment_elem is not None
+            assert segment_elem.get('state') == 'translated'
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
+    
+    def test_state_attribute_added_to_newly_translated_targets(self):
+        """
+        Test that state attribute is added to newly translated targets.
+        
+        Behavior: When update_xliff_targets adds new units from source, it should
+        add the state attribute to those new units.
+        """
+        # Target file (empty)
+        target_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': []
+            }]
+        }
+        
+        # Source file
+        source_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': ''}
+                ]
+            }]
+        }
+        
+        # Translations
+        translations = {'key1': 'Bonjour'}
+        
+        # Update with state
+        updated = update_xliff_targets(target_content, translations, source_content, target_state='translated')
+        
+        # Verify new unit has state
+        assert len(updated['files'][0]['trans-units']) == 1
+        new_unit = updated['files'][0]['trans-units'][0]
+        assert new_unit['id'] == 'key1'
+        assert new_unit['target'] == 'Bonjour'
+        assert new_unit.get('state') == 'translated'
+    
+    def test_state_attribute_respects_xliff_version_from_config(self):
+        """
+        Test that state attribute respects XLIFF version from config.
+        
+        Behavior: When writing XLIFF files, the version should determine where
+        the state attribute is placed. This is controlled by the version in the
+        content dictionary, which should come from config.
+        """
+        # Test XLIFF 1.2
+        content_12 = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': 'Bonjour', 'state': 'translated'}
+                ]
+            }]
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            temp_file_12 = f.name
+        
+        try:
+            write_xliff_file(temp_file_12, content_12, "en", "fr", "translated")
+            
+            tree = ET.parse(temp_file_12)
+            root = tree.getroot()
+            namespace = 'urn:oasis:names:tc:xliff:document:1.2'
+            target_elem = root.find(f'.//{{{namespace}}}target') or root.find('.//target')
+            
+            # For 1.2, state should be on target
+            assert target_elem is not None
+            assert target_elem.get('state') == 'translated'
+        finally:
+            if os.path.exists(temp_file_12):
+                os.unlink(temp_file_12)
+        
+        # Test XLIFF 2.0
+        content_20 = {
+            'version': '2.0',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': 'Bonjour', 'state': 'translated'}
+                ]
+            }]
+        }
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            temp_file_20 = f.name
+        
+        try:
+            write_xliff_file(temp_file_20, content_20, "en", "fr", "translated")
+            
+            tree = ET.parse(temp_file_20)
+            root = tree.getroot()
+            namespace = 'urn:oasis:names:tc:xliff:document:2.0'
+            segment_elem = root.find(f'.//{{{namespace}}}segment') or root.find('.//segment')
+            
+            # For 2.0, state should be on segment
+            assert segment_elem is not None
+            assert segment_elem.get('state') == 'translated'
+        finally:
+            if os.path.exists(temp_file_20):
+                os.unlink(temp_file_20)
+    
+    def test_state_attribute_preserved_when_updating_existing(self):
+        """
+        Test that existing state attributes are preserved when updating targets.
+        
+        Behavior: When update_xliff_targets updates an existing unit, it should
+        preserve any existing state attribute, not overwrite it.
+        """
+        # Target with existing state
+        target_content = {
+            'version': '1.2',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {
+                        'id': 'key1',
+                        'source': 'Hello',
+                        'target': 'Bonjour',
+                        'state': 'needs-review-translation'  # Existing state
+                    }
+                ]
+            }]
+        }
+        
+        # Update with new translation but no state override
+        translations = {'key1': 'Salut'}
+        updated = update_xliff_targets(target_content, translations, None, target_state=None)
+        
+        # State should be preserved (or updated if target_state is provided)
+        # This depends on implementation - if target_state is None, preserve existing
+        key1_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key1'), None)
+        assert key1_unit is not None
+        # The state might be preserved or updated based on implementation
+        assert 'state' in key1_unit
+

--- a/tests/test_xliff_state_attribute.py
+++ b/tests/test_xliff_state_attribute.py
@@ -54,13 +54,17 @@ class TestXLIFFStateAttribute:
             
             # Find target element
             namespace = 'urn:oasis:names:tc:xliff:document:1.2'
-            target_elem = root.find(f'.//{{{namespace}}}target') or root.find('.//target')
+            target_elem = root.find(f'.//{{{namespace}}}target')
+            if target_elem is None:
+                target_elem = root.find('.//target')
             
             assert target_elem is not None
             assert target_elem.get('state') == 'translated'
             
             # Verify state is NOT on segment (XLIFF 1.2 doesn't have segment)
-            segment_elem = root.find(f'.//{{{namespace}}}segment') or root.find('.//segment')
+            segment_elem = root.find(f'.//{{{namespace}}}segment')
+            if segment_elem is None:
+                segment_elem = root.find('.//segment')
             assert segment_elem is None  # XLIFF 1.2 doesn't use segment
         finally:
             if os.path.exists(temp_file):
@@ -102,7 +106,9 @@ class TestXLIFFStateAttribute:
             
             # Find segment element
             namespace = 'urn:oasis:names:tc:xliff:document:2.0'
-            segment_elem = root.find(f'.//{{{namespace}}}segment') or root.find('.//segment')
+            segment_elem = root.find(f'.//{{{namespace}}}segment')
+            if segment_elem is None:
+                segment_elem = root.find('.//segment')
             
             assert segment_elem is not None
             assert segment_elem.get('state') == 'translated'
@@ -184,7 +190,9 @@ class TestXLIFFStateAttribute:
             tree = ET.parse(temp_file_12)
             root = tree.getroot()
             namespace = 'urn:oasis:names:tc:xliff:document:1.2'
-            target_elem = root.find(f'.//{{{namespace}}}target') or root.find('.//target')
+            target_elem = root.find(f'.//{{{namespace}}}target')
+            if target_elem is None:
+                target_elem = root.find('.//target')
             
             # For 1.2, state should be on target
             assert target_elem is not None
@@ -215,7 +223,9 @@ class TestXLIFFStateAttribute:
             tree = ET.parse(temp_file_20)
             root = tree.getroot()
             namespace = 'urn:oasis:names:tc:xliff:document:2.0'
-            segment_elem = root.find(f'.//{{{namespace}}}segment') or root.find('.//segment')
+            segment_elem = root.find(f'.//{{{namespace}}}segment')
+            if segment_elem is None:
+                segment_elem = root.find('.//segment')
             
             # For 2.0, state should be on segment
             assert segment_elem is not None

--- a/tests/test_xliff_state_attribute.py
+++ b/tests/test_xliff_state_attribute.py
@@ -269,4 +269,197 @@ class TestXLIFFStateAttribute:
         assert key1_unit is not None
         # The state might be preserved or updated based on implementation
         assert 'state' in key1_unit
+    
+    def test_state_attribute_added_to_existing_units_without_state(self):
+        """
+        Test that state attribute is added to existing units that don't have a state.
+        
+        Behavior: When update_xliff_targets is called with target_state, it should add
+        the state to existing units that don't have one yet. This allows default_target_state
+        from config to be applied to units that were added before the config was set.
+        """
+        # Target with existing units but no state
+        target_content = {
+            'version': '2.0',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {
+                        'id': 'key1',
+                        'source': 'Hello',
+                        'target': 'Bonjour'
+                        # No state attribute
+                    },
+                    {
+                        'id': 'key2',
+                        'source': 'World',
+                        'target': 'Monde',
+                        'state': 'needs-review-translation'  # Has existing state
+                    }
+                ]
+            }]
+        }
+        
+        # Update with target_state - should add state to key1 but preserve key2's state
+        translations = {'key1': 'Salut', 'key2': 'Monde'}
+        updated = update_xliff_targets(target_content, translations, None, target_state='translated')
+        
+        # Verify key1 got state added
+        key1_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key1'), None)
+        assert key1_unit is not None
+        assert key1_unit.get('state') == 'translated'  # State was added
+        
+        # Verify key2's existing state was preserved
+        key2_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key2'), None)
+        assert key2_unit is not None
+        assert key2_unit.get('state') == 'needs-review-translation'  # Existing state preserved
+    
+    def test_state_attribute_added_to_existing_units_with_only_missing(self):
+        """
+        Test that state attribute is added to existing units when using only_missing flag.
+        
+        Behavior: When using --only-missing flag, existing units that don't have a state
+        should get the state attribute added if target_state is provided. This ensures
+        that default_target_state from config is applied even when preserving existing translations.
+        """
+        # Target with existing units but no state
+        target_content = {
+            'version': '2.0',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {
+                        'id': 'key1',
+                        'source': 'Hello',
+                        'target': 'Bonjour'  # Existing translation, no state
+                    }
+                ]
+            }]
+        }
+        
+        # Update with only_missing=True and target_state
+        # key1 already has a target, so it should be preserved but get state added
+        translations = {'key1': 'Salut'}  # This should be ignored due to only_missing
+        updated = update_xliff_targets(target_content, translations, None, target_state='needs-review-translation', only_missing=True)
+        
+        # Verify key1's target was preserved
+        key1_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key1'), None)
+        assert key1_unit is not None
+        assert key1_unit['target'] == 'Bonjour'  # Target preserved
+        
+        # Verify key1 got state added even though target was preserved
+        assert key1_unit.get('state') == 'needs-review-translation'  # State was added
+    
+    def test_state_attribute_on_segment_xliff_20_with_only_missing(self):
+        """
+        Test that state attribute is placed on <segment> element for XLIFF 2.0 when using only_missing flag.
+        
+        Behavior: When using --only-missing flag with XLIFF 2.0 files, the state attribute should be
+        placed on the <segment> element, not on <target>. This is the correct behavior per XLIFF 2.0 spec.
+        """
+        # Target file with one existing translation
+        target_content = {
+            'version': '2.0',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': 'Bonjour'}  # Already translated
+                ]
+            }]
+        }
+        
+        # Source file with two keys
+        source_content = {
+            'version': '2.0',
+            'files': [{
+                'original': 'messages',
+                'source-language': 'en',
+                'target-language': 'fr',
+                'trans-units': [
+                    {'id': 'key1', 'source': 'Hello', 'target': ''},
+                    {'id': 'key2', 'source': 'World', 'target': ''}  # Missing
+                ]
+            }]
+        }
+        
+        # Translations dict contains both keys, but only key2 should be added (only_missing=True)
+        translations = {
+            'key1': 'Salut',  # Should be ignored (already exists)
+            'key2': 'Monde'   # Should be added (missing)
+        }
+        
+        # Update with only_missing=True and target_state
+        updated = update_xliff_targets(target_content, translations, source_content, target_state='translated', only_missing=True)
+        
+        # Verify key1 was NOT overwritten
+        key1_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key1'), None)
+        assert key1_unit is not None
+        assert key1_unit['target'] == 'Bonjour'  # Original preserved, not 'Salut'
+        
+        # Verify key2 was added with state
+        key2_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key2'), None)
+        assert key2_unit is not None
+        assert key2_unit['target'] == 'Monde'
+        assert key2_unit.get('state') == 'translated'
+        
+        # Write to file and verify state is on segment, not target
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False, encoding='utf-8') as f:
+            temp_file = f.name
+        
+        try:
+            write_xliff_file(temp_file, updated, "en", "fr", "translated")
+            
+            # Read back and verify state is on segment for XLIFF 2.0
+            tree = ET.parse(temp_file)
+            root = tree.getroot()
+            
+            # Verify version is 2.0
+            assert root.get('version') == '2.0'
+            
+            namespace = 'urn:oasis:names:tc:xliff:document:2.0'
+            
+            # Find segment elements
+            segments = root.findall(f'.//{{{namespace}}}segment')
+            if not segments:
+                segments = root.findall('.//segment')
+            
+            assert len(segments) >= 2  # At least key1 and key2
+            
+            # Find the segment for key2 (the newly added one)
+            # We need to find the unit with id="key2" and then its segment
+            units = root.findall(f'.//{{{namespace}}}unit')
+            if not units:
+                units = root.findall('.//unit')
+            
+            key2_unit_elem = None
+            for unit in units:
+                if unit.get('id') == 'key2':
+                    key2_unit_elem = unit
+                    break
+            
+            assert key2_unit_elem is not None
+            key2_segment = key2_unit_elem.find(f'{{{namespace}}}segment')
+            if key2_segment is None:
+                key2_segment = key2_unit_elem.find('segment')
+            
+            assert key2_segment is not None
+            # State should be on segment for XLIFF 2.0
+            assert key2_segment.get('state') == 'translated'
+            
+            # Verify state is NOT on target element
+            key2_target = key2_segment.find(f'{{{namespace}}}target')
+            if key2_target is None:
+                key2_target = key2_segment.find('target')
+            
+            assert key2_target is not None
+            assert key2_target.get('state') is None  # State should NOT be on target
+        finally:
+            if os.path.exists(temp_file):
+                os.unlink(temp_file)
 

--- a/tests/test_xliff_state_attribute.py
+++ b/tests/test_xliff_state_attribute.py
@@ -272,11 +272,11 @@ class TestXLIFFStateAttribute:
     
     def test_state_attribute_added_to_existing_units_without_state(self):
         """
-        Test that state attribute is added to existing units that don't have a state.
+        Test that state attribute is NOT added to existing units, only preserved if present.
         
-        Behavior: When update_xliff_targets is called with target_state, it should add
-        the state to existing units that don't have one yet. This allows default_target_state
-        from config to be applied to units that were added before the config was set.
+        Behavior: When update_xliff_targets is called with target_state, it should NOT add
+        the state to existing units. State is only added to new units from source_content.
+        This prevents changing the state of units that were already reviewed/translated.
         """
         # Target with existing units but no state
         target_content = {
@@ -302,14 +302,14 @@ class TestXLIFFStateAttribute:
             }]
         }
         
-        # Update with target_state - should add state to key1 but preserve key2's state
+        # Update with target_state - should NOT add state to key1, but preserve key2's state
         translations = {'key1': 'Salut', 'key2': 'Monde'}
         updated = update_xliff_targets(target_content, translations, None, target_state='translated')
         
-        # Verify key1 got state added
+        # Verify key1 did NOT get state added (existing units don't get state)
         key1_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key1'), None)
         assert key1_unit is not None
-        assert key1_unit.get('state') == 'translated'  # State was added
+        assert 'state' not in key1_unit  # State was NOT added to existing unit
         
         # Verify key2's existing state was preserved
         key2_unit = next((u for u in updated['files'][0]['trans-units'] if u['id'] == 'key2'), None)
@@ -318,11 +318,11 @@ class TestXLIFFStateAttribute:
     
     def test_state_attribute_added_to_existing_units_with_only_missing(self):
         """
-        Test that state attribute is added to existing units when using only_missing flag.
+        Test that state attribute is NOT added to existing units when using only_missing flag.
         
-        Behavior: When using --only-missing flag, existing units that don't have a state
-        should get the state attribute added if target_state is provided. This ensures
-        that default_target_state from config is applied even when preserving existing translations.
+        Behavior: When using --only-missing flag, existing units should NOT get the state
+        attribute added. State is only added to new units from source_content. This prevents
+        changing the state of units that were already reviewed/translated.
         """
         # Target with existing units but no state
         target_content = {
@@ -342,7 +342,7 @@ class TestXLIFFStateAttribute:
         }
         
         # Update with only_missing=True and target_state
-        # key1 already has a target, so it should be preserved but get state added
+        # key1 already has a target, so it should be preserved and state should NOT be added
         translations = {'key1': 'Salut'}  # This should be ignored due to only_missing
         updated = update_xliff_targets(target_content, translations, None, target_state='needs-review-translation', only_missing=True)
         
@@ -351,8 +351,8 @@ class TestXLIFFStateAttribute:
         assert key1_unit is not None
         assert key1_unit['target'] == 'Bonjour'  # Target preserved
         
-        # Verify key1 got state added even though target was preserved
-        assert key1_unit.get('state') == 'needs-review-translation'  # State was added
+        # Verify key1 did NOT get state added (existing units don't get state)
+        assert 'state' not in key1_unit  # State was NOT added to existing unit
     
     def test_state_attribute_on_segment_xliff_20_with_only_missing(self):
         """

--- a/tests/test_xliff_translation_from_scratch_fix.py
+++ b/tests/test_xliff_translation_from_scratch_fix.py
@@ -1,0 +1,510 @@
+"""
+Tests for XLIFF translation from scratch bug fix.
+
+This test file covers the fix for the issue where XLIFF translations
+were using source text instead of actual translations when creating
+target files from scratch.
+
+Bug: translate_command.py was incorrectly handling the return value from
+translator.translate_file() for XLIFF files, treating it as a flat dict
+when it was actually a structured dict, resulting in empty translations
+and fallback to source text.
+
+Fix: Changed XLIFF handling to extract strings first, translate as flat dict,
+then update structure properly.
+"""
+
+import os
+import tempfile
+import json
+from unittest.mock import patch, MagicMock, Mock
+from io import StringIO
+
+import pytest
+
+from algebras.utils.xliff_handler import (
+    read_xliff_file,
+    write_xliff_file,
+    extract_translatable_strings,
+    update_xliff_targets
+)
+from algebras.services.translator import Translator
+from algebras.config import Config
+
+
+class TestXLIFFTranslationFromScratchFix:
+    """Test the fix for XLIFF translation from scratch bug."""
+    
+    @pytest.fixture
+    def source_xliff_content(self):
+        """Create a sample source XLIFF file content."""
+        return '''<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-US">
+  <file id="ngi18n" original="ng.template">
+    <unit id="test.general">
+      <segment>
+        <source>General</source>
+      </segment>
+    </unit>
+    <unit id="test.display">
+      <segment>
+        <source>Display</source>
+      </segment>
+    </unit>
+    <unit id="test.patient">
+      <segment>
+        <source>Patient management</source>
+      </segment>
+    </unit>
+  </file>
+</xliff>'''
+    
+    @pytest.fixture
+    def mock_translations(self):
+        """Mock translations that should be returned by the translator."""
+        return {
+            "test.general": "Общее",
+            "test.display": "Отображение",
+            "test.patient": "Управление пациентами"
+        }
+    
+    def test_extract_translatable_strings_from_xliff(self, source_xliff_content):
+        """Test that we can extract flat strings from XLIFF structure."""
+        # Create temp file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as f:
+            f.write(source_xliff_content)
+            temp_file = f.name
+        
+        try:
+            # Read and extract
+            content = read_xliff_file(temp_file)
+            strings = extract_translatable_strings(content)
+            
+            # Verify we got flat dictionary
+            assert isinstance(strings, dict)
+            assert "test.general" in strings
+            assert strings["test.general"] == "General"
+            assert "test.display" in strings
+            assert strings["test.display"] == "Display"
+            assert "test.patient" in strings
+            assert strings["test.patient"] == "Patient management"
+        finally:
+            os.unlink(temp_file)
+    
+    def test_update_xliff_targets_with_translations(self, source_xliff_content, mock_translations):
+        """Test that update_xliff_targets properly applies translations."""
+        # Create temp source file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as f:
+            f.write(source_xliff_content)
+            source_file = f.name
+        
+        try:
+            # Read source
+            source_content = read_xliff_file(source_file)
+            
+            # Create empty target
+            target_content = {'version': '2.0', 'files': []}
+            
+            # Update with translations
+            updated_content = update_xliff_targets(
+                target_content,
+                mock_translations,
+                source_content,
+                "translated"
+            )
+            
+            # Verify structure
+            assert 'version' in updated_content
+            assert updated_content['version'] == '2.0'
+            assert 'files' in updated_content
+            assert len(updated_content['files']) > 0
+            
+            # Verify translations were applied (not source text)
+            trans_units = updated_content['files'][0]['trans-units']
+            
+            # Find the units and verify they have translations, not source text
+            general_unit = next(u for u in trans_units if u['id'] == 'test.general')
+            assert general_unit['source'] == "General"
+            assert general_unit['target'] == "Общее"  # Translation, not source!
+            
+            display_unit = next(u for u in trans_units if u['id'] == 'test.display')
+            assert display_unit['source'] == "Display"
+            assert display_unit['target'] == "Отображение"  # Translation, not source!
+            
+            patient_unit = next(u for u in trans_units if u['id'] == 'test.patient')
+            assert patient_unit['source'] == "Patient management"
+            assert patient_unit['target'] == "Управление пациентами"  # Translation, not source!
+            
+        finally:
+            os.unlink(source_file)
+    
+    def test_update_xliff_targets_without_translations_uses_empty_string(self, source_xliff_content):
+        """Test that update_xliff_targets uses empty string (not source) when no translation provided."""
+        # Create temp source file
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as f:
+            f.write(source_xliff_content)
+            source_file = f.name
+        
+        try:
+            # Read source
+            source_content = read_xliff_file(source_file)
+            
+            # Create empty target
+            target_content = {'version': '2.0', 'files': []}
+            
+            # Update with NO translations (empty dict)
+            updated_content = update_xliff_targets(
+                target_content,
+                {},  # Empty translations!
+                source_content,
+                "translated"
+            )
+            
+            # Verify units were added but with empty targets (not source text)
+            trans_units = updated_content['files'][0]['trans-units']
+            
+            general_unit = next(u for u in trans_units if u['id'] == 'test.general')
+            assert general_unit['source'] == "General"
+            # CRITICAL: Should be empty string, NOT "General"
+            assert general_unit['target'] == ""
+            
+        finally:
+            os.unlink(source_file)
+    
+    def test_write_xliff_file_with_translations(self, mock_translations):
+        """Test writing XLIFF file with proper translations."""
+        # Create XLIFF content with translations
+        xliff_content = {
+            'version': '2.0',
+            'files': [{
+                'original': 'ng.template',
+                'source-language': 'en-US',
+                'target-language': 'ru',
+                'trans-units': [
+                    {
+                        'id': 'test.general',
+                        'source': 'General',
+                        'target': mock_translations['test.general'],
+                        'state': 'translated'
+                    },
+                    {
+                        'id': 'test.display',
+                        'source': 'Display',
+                        'target': mock_translations['test.display'],
+                        'state': 'translated'
+                    }
+                ]
+            }]
+        }
+        
+        with tempfile.NamedTemporaryFile(suffix='.xlf', delete=False) as f:
+            target_file = f.name
+        
+        try:
+            # Write file
+            write_xliff_file(target_file, xliff_content, 'en-US', 'ru', 'translated')
+            
+            # Read back and verify
+            result = read_xliff_file(target_file)
+            trans_units = result['files'][0]['trans-units']
+            
+            general_unit = next(u for u in trans_units if u['id'] == 'test.general')
+            # Verify target has translation, not source
+            assert general_unit['target'] == "Общее"
+            assert general_unit['target'] != general_unit['source']
+            
+        finally:
+            os.unlink(target_file)
+    
+    def test_translator_verbose_mode(self):
+        """Test that translator verbose mode can be enabled."""
+        # Create mock config
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.get_api_config.return_value = {'provider': 'algebras-ai'}
+        mock_config.get_languages.return_value = ['en', 'ru']
+        
+        # Create translator
+        translator = Translator(config=mock_config)
+        
+        # Initially verbose should be False
+        assert translator.verbose is False
+        
+        # Enable verbose
+        translator.set_verbose(True)
+        assert translator.verbose is True
+        
+        # Disable verbose
+        translator.set_verbose(False)
+        assert translator.verbose is False
+    
+    @patch('algebras.services.translator.requests.post')
+    @patch('sys.stdout', new_callable=StringIO)
+    def test_translator_verbose_logging(self, mock_stdout, mock_post):
+        """Test that verbose mode produces debug output."""
+        # Mock successful API response
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'data': {
+                'translations': [
+                    {'index': 0, 'content': 'Общее'}
+                ]
+            }
+        }
+        mock_post.return_value = mock_response
+        
+        # Create mock config
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.get_api_config.return_value = {'provider': 'algebras-ai'}
+        mock_config.get_languages.return_value = ['en', 'ru']
+        mock_config.get_base_url.return_value = 'https://api.example.com'
+        
+        # Create translator with verbose enabled
+        translator = Translator(config=mock_config)
+        translator.set_verbose(True)
+        
+        # Mock environment
+        with patch.dict(os.environ, {'ALGEBRAS_API_KEY': 'test-key'}):
+            # Call batch translation
+            result = translator._translate_with_algebras_ai_batch(
+                ['General'],
+                'en',
+                'ru',
+                False,
+                ''
+            )
+        
+        # Verify result
+        assert result == ['Общее']
+        
+        # Verify verbose output was produced
+        output = mock_stdout.getvalue()
+        assert '[API Request]' in output or 'Translating' in output
+    
+    def test_update_xliff_targets_preserves_version(self, source_xliff_content, mock_translations):
+        """Test that version is preserved during update."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as f:
+            f.write(source_xliff_content)
+            source_file = f.name
+        
+        try:
+            source_content = read_xliff_file(source_file)
+            target_content = {'version': '2.0', 'files': []}
+            
+            updated_content = update_xliff_targets(
+                target_content,
+                mock_translations,
+                source_content,
+                "translated"
+            )
+            
+            # Verify version was preserved
+            assert 'version' in updated_content
+            assert updated_content['version'] == '2.0'
+            
+        finally:
+            os.unlink(source_file)
+    
+    def test_update_xliff_targets_adds_state_to_new_units(self, source_xliff_content, mock_translations):
+        """Test that state attribute is added to new units."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as f:
+            f.write(source_xliff_content)
+            source_file = f.name
+        
+        try:
+            source_content = read_xliff_file(source_file)
+            target_content = {'version': '2.0', 'files': []}
+            
+            # Custom state
+            custom_state = "needs-review"
+            
+            updated_content = update_xliff_targets(
+                target_content,
+                mock_translations,
+                source_content,
+                custom_state
+            )
+            
+            # Verify state was added to all new units
+            trans_units = updated_content['files'][0]['trans-units']
+            for unit in trans_units:
+                assert 'state' in unit
+                assert unit['state'] == custom_state
+            
+        finally:
+            os.unlink(source_file)
+    
+    def test_update_xliff_targets_preserves_existing_state(self, source_xliff_content, mock_translations):
+        """Test that existing unit states are preserved, not overwritten."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as f:
+            f.write(source_xliff_content)
+            source_file = f.name
+        
+        try:
+            source_content = read_xliff_file(source_file)
+            
+            # Create target with existing units that have state
+            target_content = {
+                'version': '2.0',
+                'files': [{
+                    'original': 'ng.template',
+                    'source-language': 'en-US',
+                    'target-language': 'ru',
+                    'trans-units': [
+                        {
+                            'id': 'test.general',
+                            'source': 'General',
+                            'target': 'Старое значение',
+                            'state': 'final'  # Existing state
+                        }
+                    ]
+                }]
+            }
+            
+            # Update with new translations and new state
+            updated_content = update_xliff_targets(
+                target_content,
+                mock_translations,
+                source_content,
+                "translated"  # This should NOT override existing "final" state
+            )
+            
+            # Find the existing unit
+            trans_units = updated_content['files'][0]['trans-units']
+            general_unit = next(u for u in trans_units if u['id'] == 'test.general')
+            
+            # Verify existing state was preserved
+            assert general_unit['state'] == 'final'  # NOT "translated"
+            
+            # But translation should be updated
+            assert general_unit['target'] == mock_translations['test.general']
+            
+        finally:
+            os.unlink(source_file)
+
+
+class TestXLIFFTranslationEndToEnd:
+    """End-to-end integration tests for XLIFF translation from scratch."""
+    
+    def test_full_translation_workflow(self):
+        """Test complete workflow: source XLIFF → extract → translate → write target."""
+        # Step 1: Create source XLIFF
+        source_xliff = '''<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-US">
+  <file id="test" original="test.template">
+    <unit id="app.title">
+      <segment>
+        <source>My Application</source>
+      </segment>
+    </unit>
+    <unit id="app.welcome">
+      <segment>
+        <source>Welcome to our app!</source>
+      </segment>
+    </unit>
+  </file>
+</xliff>'''
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as f:
+            f.write(source_xliff)
+            source_file = f.name
+        
+        target_file = tempfile.NamedTemporaryFile(suffix='.xlf', delete=False).name
+        
+        try:
+            # Step 2: Read source and extract strings
+            source_content = read_xliff_file(source_file)
+            source_strings = extract_translatable_strings(source_content)
+            
+            assert source_strings == {
+                "app.title": "My Application",
+                "app.welcome": "Welcome to our app!"
+            }
+            
+            # Step 3: Simulate translation (in real code, this would call translator._translate_flat_dict)
+            translated_strings = {
+                "app.title": "Mi Aplicación",
+                "app.welcome": "¡Bienvenido a nuestra aplicación!"
+            }
+            
+            # Step 4: Create empty target and update with translations
+            target_content = {'version': '2.0', 'files': []}
+            updated_content = update_xliff_targets(
+                target_content,
+                translated_strings,
+                source_content,
+                "translated"
+            )
+            
+            # Step 5: Write target file
+            write_xliff_file(target_file, updated_content, 'en-US', 'es', 'translated')
+            
+            # Step 6: Verify target file
+            result = read_xliff_file(target_file)
+            result_strings = extract_translatable_strings(result)
+            
+            # Verify we have source text in source elements
+            trans_units = result['files'][0]['trans-units']
+            title_unit = next(u for u in trans_units if u['id'] == 'app.title')
+            assert title_unit['source'] == "My Application"
+            assert title_unit['target'] == "Mi Aplicación"
+            
+            welcome_unit = next(u for u in trans_units if u['id'] == 'app.welcome')
+            assert welcome_unit['source'] == "Welcome to our app!"
+            assert welcome_unit['target'] == "¡Bienvenido a nuestra aplicación!"
+            
+            # CRITICAL: Verify targets contain translations, NOT source text
+            assert title_unit['target'] != title_unit['source']
+            assert welcome_unit['target'] != welcome_unit['source']
+            
+        finally:
+            os.unlink(source_file)
+            os.unlink(target_file)
+    
+    def test_regression_source_text_not_used_as_fallback(self):
+        """Regression test: Ensure source text is NOT used when translations are missing."""
+        source_xliff = '''<?xml version="1.0" encoding="UTF-8" ?>
+<xliff version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" srcLang="en-US">
+  <file id="test" original="test.template">
+    <unit id="test.key">
+      <segment>
+        <source>English Text</source>
+      </segment>
+    </unit>
+  </file>
+</xliff>'''
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xlf', delete=False) as f:
+            f.write(source_xliff)
+            source_file = f.name
+        
+        try:
+            source_content = read_xliff_file(source_file)
+            
+            # Update with EMPTY translations dict (simulate translation failure)
+            target_content = {'version': '2.0', 'files': []}
+            updated_content = update_xliff_targets(
+                target_content,
+                {},  # No translations!
+                source_content,
+                "translated"
+            )
+            
+            # Verify target is empty string, NOT source text
+            trans_units = updated_content['files'][0]['trans-units']
+            unit = trans_units[0]
+            
+            assert unit['source'] == "English Text"
+            # CRITICAL: This should be empty, NOT "English Text"
+            assert unit['target'] == ""
+            assert unit['target'] != unit['source']
+            
+        finally:
+            os.unlink(source_file)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Strengthens end-to-end XLIFF support and validation, with version-aware writing/parsing and safer update semantics.
> 
> - Implement XLIFF version detection (configurable default), correct state placement (1.2: `target`, 2.0: `segment`), and creation of target files when missing
> - Update `update_xliff_targets` to preserve existing translations/state, add only missing units, support `only_missing`, and use empty targets when no translation is provided
> - Healthcheck passes `is_xliff` and runs XLIFF-specific placeholder checks (`ph`, `pc`, `sc`, `ec`, `mrk`) via enhanced `validate_translation`
> - Translator gains verbose mode with API request/response logging; translate command surfaces verbose info and reads prompt/config, handling XLIFF via flat-dict extraction and structured writes
> - Fix XLIFF translate-from-scratch path to use actual translations (no source fallbacks) and ensure version/state are preserved when writing
> - Extensive tests added for config prompts, placeholder detection, state placement, only-missing behavior, and end-to-end XLIFF translation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4b1013f748160958e4dcdb45b00bba13faaaf25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->