### PR TITLE
Support plurals

### DIFF
--- a/algebras/commands/update_command.py
+++ b/algebras/commands/update_command.py
@@ -171,6 +171,7 @@ def identify_translation_issues(
             
             # Check for missing keys
             if check_missing_keys:
+                # #endregion
                 is_valid, missing_keys = validate_language_files(src_file, tgt_file)
                 if not is_valid:
                     results["missing_keys"] = missing_keys

--- a/algebras/services/translator.py
+++ b/algebras/services/translator.py
@@ -695,6 +695,17 @@ class Translator:
                         texts_to_translate.append(source_value)
                         key_paths_list.append(key_path)
                         key_parts_list.append([key_path])  # Treat as single-level key
+                elif isinstance(source_value, dict):
+                    # Handle plural/dict values (e.g., Android XML plurals)
+                    # Each plural form (one, other, etc.) needs to be translated separately
+                    for plural_key, plural_value in source_value.items():
+                        if isinstance(plural_value, str) and plural_value.strip():
+                            # Create a composite key for this plural form (e.g., "Plural.tasks.__plurals__.one")
+                            composite_key = f"{key_path}.{plural_key}"
+                            texts_to_translate.append(plural_value)
+                            key_paths_list.append(composite_key)
+                            key_parts_list.append([key_path, plural_key])  # Store as nested structure
+                            print(f"DEBUG: ✓ Added plural form '{composite_key}' to translation queue")
             else:
                 # Try to treat it as a dot-notation path (nested format)
                 key_parts = key_path.split(".")
@@ -825,11 +836,25 @@ class Translator:
                     if len(key_parts) == 1:
                         # Flat format - set directly
                         updated_content[key_parts[0]] = normalized
+                    elif len(key_parts) == 2 and key_parts[0].endswith('.__plurals__'):
+                        # Handle plurals - reconstruct dictionary structure
+                        plural_base_key = key_parts[0]  # e.g., "Quiz.timer_format.__plurals__"
+                        plural_form = key_parts[1]      # e.g., "one" or "other"
+                        
+                        # Initialize plural dict if it doesn't exist
+                        if plural_base_key not in updated_content:
+                            updated_content[plural_base_key] = {}
+                        elif not isinstance(updated_content[plural_base_key], dict):
+                            # Convert to dict if it wasn't one already
+                            updated_content[plural_base_key] = {}
+                        
+                        # Set the plural form
+                        updated_content[plural_base_key][plural_form] = normalized
+                        print(f"  ✓ Translated plural: {key_path}")
                     else:
                         # Nested format - use nested value setter
                         set_nested_value(updated_content, key_parts, normalized)
                     batch_dict[key_path] = normalized
-                    print(f"  ✓ Translated: {key_path}")
 
             # Call callback if provided
             if on_batch_complete and batch_dict:
@@ -983,11 +1008,25 @@ class Translator:
                     if len(key_parts) == 1:
                         # Flat format - set directly
                         updated_content[key_parts[0]] = normalized
+                    elif len(key_parts) == 2 and key_parts[0].endswith('.__plurals__'):
+                        # Handle plurals - reconstruct dictionary structure
+                        plural_base_key = key_parts[0]  # e.g., "Quiz.timer_format.__plurals__"
+                        plural_form = key_parts[1]      # e.g., "one" or "other"
+                        
+                        # Initialize plural dict if it doesn't exist
+                        if plural_base_key not in updated_content:
+                            updated_content[plural_base_key] = {}
+                        elif not isinstance(updated_content[plural_base_key], dict):
+                            # Convert to dict if it wasn't one already
+                            updated_content[plural_base_key] = {}
+                        
+                        # Set the plural form
+                        updated_content[plural_base_key][plural_form] = normalized
+                        print(f"  ✓ Translated plural: {key_path}")
                     else:
                         # Nested format - use nested value setter
                         set_nested_value(updated_content, key_parts, normalized)
                     batch_dict[key_path] = normalized
-                    print(f"  ✓ Translated: {key_path}")
 
             # Call callback if provided
             if on_batch_complete and batch_dict:

--- a/examples/android-app/app/src/main/res/values-es/app_strings.xml
+++ b/examples/android-app/app/src/main/res/values-es/app_strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="error_generic">Algo salió mal</string>
+    <string name="error_network">Ocurrió un error de red</string>
+    <string name="loading_message">Cargando...</string>
+    <string name="no_data_message">No hay datos disponibles</string>
+    <string name="retry_button">Reintentar</string>
+</resources>

--- a/examples/android-app/app/src/main/res/values-es/strings.xml
+++ b/examples/android-app/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Mi aplicación de Android</string>
+    <string name="cancel_button">Cancelar</string>
+    <plurals name="items_count">
+        <item quantity="zero">No hay objetos</item>
+        <item quantity="one">Un objeto</item>
+        <item quantity="other">%d elementos</item>
+    </plurals>
+    <string name="login_button">Iniciar sesión</string>
+    <string name="logout_button">Cerrar sesión</string>
+    <plurals name="notifications_count">
+        <item quantity="zero">Sin notificaciones</item>
+        <item quantity="one">Una notificación</item>
+        <item quantity="other">%d notificaciones</item>
+    </plurals>
+    <string name="profile_title">Perfil</string>
+    <string name="save_button">Guardar</string>
+    <string name="settings_title">Ajustes</string>
+    <string name="welcome_message">¡Bienvenido a nuestra aplicación!</string>
+</resources>

--- a/examples/ios-app/MyiOSApp/en.lproj/InfoPlist.strings
+++ b/examples/ios-app/MyiOSApp/en.lproj/InfoPlist.strings
@@ -1,0 +1,16 @@
+/* 
+  InfoPlist.strings
+  MyiOSApp (English)
+  
+  Localized values for Info.plist keys
+*/
+
+/* Display name of the app */
+CFBundleDisplayName = "My iOS App";
+CFBundleName = "MyiOSApp";
+
+/* Privacy permission descriptions */
+NSCameraUsageDescription = "This app needs access to your camera to take photos.";
+NSPhotoLibraryUsageDescription = "This app needs access to your photo library to select images.";
+NSLocationWhenInUseUsageDescription = "This app needs access to your location to show nearby places.";
+NSMicrophoneUsageDescription = "This app needs access to your microphone for voice recording.";

--- a/examples/ios-app/MyiOSApp/en.lproj/Localizable.strings
+++ b/examples/ios-app/MyiOSApp/en.lproj/Localizable.strings
@@ -1,0 +1,33 @@
+/* 
+  Localizable.strings
+  MyiOSApp (English)
+*/
+
+/* App UI strings */
+"app_name" = "My iOS App";
+"welcome_message" = "Welcome to our app!";
+"login_button" = "Log In";
+"logout_button" = "Log Out";
+"settings_title" = "Settings";
+"profile_title" = "Profile";
+"save_button" = "Save";
+"cancel_button" = "Cancel";
+
+/* Notifications */
+"notifications_title" = "Notifications";
+"no_notifications" = "No notifications";
+"notification_received" = "You have a new notification";
+
+/* Errors */
+"error_network" = "Network connection error. Please try again.";
+"error_authentication" = "Authentication failed";
+"error_generic" = "An error occurred";
+
+/* Plurals - iOS uses stringsdict for plurals, but simple cases can be in .strings */
+"items_count_zero" = "No items";
+"items_count_one" = "One item";
+"items_count_other" = "%d items";
+
+/* Formatted strings */
+"greeting_user" = "Hello, %@!";
+"items_selected" = "%d of %d items selected";

--- a/examples/ios-app/MyiOSApp/en.lproj/Localizable.stringsdict
+++ b/examples/ios-app/MyiOSApp/en.lproj/Localizable.stringsdict
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Items count with proper plural rules -->
+    <key>items_count</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@item_count@</string>
+        <key>item_count</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>zero</key>
+            <string>No items</string>
+            <key>one</key>
+            <string>One item</string>
+            <key>other</key>
+            <string>%d items</string>
+        </dict>
+    </dict>
+    
+    <!-- Notifications count with proper plural rules -->
+    <key>notifications_count</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@notification_count@</string>
+        <key>notification_count</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>zero</key>
+            <string>No notifications</string>
+            <key>one</key>
+            <string>One notification</string>
+            <key>other</key>
+            <string>%d notifications</string>
+        </dict>
+    </dict>
+    
+    <!-- Days remaining -->
+    <key>days_remaining</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@day_count@</string>
+        <key>day_count</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>zero</key>
+            <string>No days remaining</string>
+            <key>one</key>
+            <string>One day remaining</string>
+            <key>other</key>
+            <string>%d days remaining</string>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/examples/ios-app/MyiOSApp/es.lproj/InfoPlist.strings
+++ b/examples/ios-app/MyiOSApp/es.lproj/InfoPlist.strings
@@ -1,0 +1,16 @@
+/* 
+  InfoPlist.strings
+  MyiOSApp (Spanish)
+  
+  Localized values for Info.plist keys
+*/
+
+/* Display name of the app */
+CFBundleDisplayName = "Mi aplicación iOS";
+CFBundleName = "MyiOSApp";
+
+/* Privacy permission descriptions */
+NSCameraUsageDescription = "Esta aplicación necesita acceso a tu cámara para tomar fotos.";
+NSPhotoLibraryUsageDescription = "Esta aplicación necesita acceso a tu biblioteca de fotos para seleccionar imágenes.";
+NSLocationWhenInUseUsageDescription = "Esta aplicación necesita acceso a tu ubicación para mostrar lugares cercanos.";
+NSMicrophoneUsageDescription = "Esta aplicación necesita acceso a tu micrófono para la grabación de voz.";

--- a/examples/ios-app/MyiOSApp/es.lproj/Localizable.strings
+++ b/examples/ios-app/MyiOSApp/es.lproj/Localizable.strings
@@ -1,0 +1,33 @@
+/* 
+  Localizable.strings
+  MyiOSApp (Spanish)
+*/
+
+/* App UI strings */
+"app_name" = "Mi aplicación iOS";
+"welcome_message" = "¡Bienvenido a nuestra aplicación!";
+"login_button" = "Iniciar sesión";
+"logout_button" = "Cerrar sesión";
+"settings_title" = "Ajustes";
+"profile_title" = "Perfil";
+"save_button" = "Guardar";
+"cancel_button" = "Cancelar";
+
+/* Notifications */
+"notifications_title" = "Notificaciones";
+"no_notifications" = "Sin notificaciones";
+"notification_received" = "Tienes una nueva notificación";
+
+/* Errors */
+"error_network" = "Error de conexión de red. Por favor, inténtalo de nuevo.";
+"error_authentication" = "Autenticación fallida";
+"error_generic" = "Ha ocurrido un error";
+
+/* Plurals - iOS uses stringsdict for plurals, but simple cases can be in .strings */
+"items_count_zero" = "No hay elementos";
+"items_count_one" = "Un elemento";
+"items_count_other" = "%d elementos";
+
+/* Formatted strings */
+"greeting_user" = "¡Hola, %@!";
+"items_selected" = "%d de %d elementos seleccionados";

--- a/examples/ios-app/MyiOSApp/es.lproj/Localizable.stringsdict
+++ b/examples/ios-app/MyiOSApp/es.lproj/Localizable.stringsdict
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Items count with proper plural rules for Spanish -->
+    <key>items_count</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@item_count@</string>
+        <key>item_count</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>zero</key>
+            <string>No hay elementos</string>
+            <key>one</key>
+            <string>Un elemento</string>
+            <key>other</key>
+            <string>%d elementos</string>
+        </dict>
+    </dict>
+    
+    <!-- Notifications count with proper plural rules for Spanish -->
+    <key>notifications_count</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@notification_count@</string>
+        <key>notification_count</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>zero</key>
+            <string>Sin notificaciones</string>
+            <key>one</key>
+            <string>Una notificación</string>
+            <key>other</key>
+            <string>%d notificaciones</string>
+        </dict>
+    </dict>
+    
+    <!-- Days remaining -->
+    <key>days_remaining</key>
+    <dict>
+        <key>NSStringLocalizedFormatKey</key>
+        <string>%#@day_count@</string>
+        <key>day_count</key>
+        <dict>
+            <key>NSStringFormatSpecTypeKey</key>
+            <string>NSStringPluralRuleType</string>
+            <key>NSStringFormatValueTypeKey</key>
+            <string>d</string>
+            <key>zero</key>
+            <string>No quedan días</string>
+            <key>one</key>
+            <string>Queda un día</string>
+            <key>other</key>
+            <string>Quedan %d días</string>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/examples/ios-app/README.md
+++ b/examples/ios-app/README.md
@@ -1,0 +1,87 @@
+# iOS App Localization Example
+
+This example demonstrates iOS app localization using `.strings` and `.stringsdict` files.
+
+## Directory Structure
+
+```
+MyiOSApp/
+├── en.lproj/                   # English localization
+│   ├── Localizable.strings     # Main app strings
+│   ├── Localizable.stringsdict # Plural rules
+│   └── InfoPlist.strings       # Info.plist localizations
+└── es.lproj/                   # Spanish localization
+    ├── Localizable.strings     # Main app strings (Spanish)
+    ├── Localizable.stringsdict # Plural rules (Spanish)
+    └── InfoPlist.strings       # Info.plist localizations (Spanish)
+```
+
+## File Types
+
+### Localizable.strings
+The main file for app UI text translations. Format:
+```
+/* Comment */
+"key" = "value";
+```
+
+### Localizable.stringsdict
+Used for pluralization rules following Unicode CLDR. This allows proper handling of:
+- Zero, one, two, few, many, other forms
+- Language-specific plural rules
+- Variable substitution with proper grammar
+
+### InfoPlist.strings
+Localizes Info.plist keys like:
+- `CFBundleDisplayName` - App display name
+- Privacy permission descriptions (NSCameraUsageDescription, etc.)
+
+## Usage in Swift
+
+```swift
+// Load localized string
+let welcomeText = NSLocalizedString("welcome_message", comment: "Welcome message")
+
+// Load with default value
+let title = NSLocalizedString("settings_title", value: "Settings", comment: "Settings screen title")
+
+// Formatted strings
+let greeting = String(format: NSLocalizedString("greeting_user", comment: ""), username)
+
+// Plurals from stringsdict
+let itemsText = String.localizedStringWithFormat(
+    NSLocalizedString("items_count", comment: ""),
+    count
+)
+```
+
+## Adding New Languages
+
+1. Create a new `.lproj` directory (e.g., `fr.lproj` for French)
+2. Copy the `.strings` and `.stringsdict` files from `en.lproj`
+3. Translate the values (keep keys unchanged)
+4. Add the language to your Xcode project settings
+
+## Best Practices
+
+1. **Always use keys**: Never hardcode user-facing strings in code
+2. **Add comments**: Help translators understand context
+3. **Use stringsdict for plurals**: Ensures grammatically correct translations
+4. **Test with pseudo-localization**: Verify your layout handles long strings
+5. **Keep InfoPlist.strings updated**: Essential for privacy permissions
+
+## Common Xcode Integration
+
+1. Add localization in Xcode: Project Settings → Info → Localizations
+2. Xcode will create `.lproj` directories automatically
+3. Use `genstrings` to extract strings from code:
+   ```bash
+   find . -name "*.swift" -print0 | xargs -0 genstrings -o en.lproj
+   ```
+
+## Notes
+
+- iOS uses ISO 639-1 language codes (e.g., `en`, `es`, `fr`)
+- Regional variants use hyphens (e.g., `en-GB`, `es-MX`)
+- Base.lproj can be used for development language fallbacks
+- Strings files must use UTF-16 encoding for special characters

--- a/tests/test_android_xml_plural_translation.py
+++ b/tests/test_android_xml_plural_translation.py
@@ -1,0 +1,379 @@
+"""
+Tests for Android XML plural translation functionality
+
+This test suite ensures that plural keys (stored as key.__plurals__ with dict values)
+are correctly handled throughout the translation pipeline, preventing regression of
+the bug where plural keys were not being translated.
+"""
+
+import os
+import tempfile
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from algebras.config import Config
+from algebras.services.translator import Translator
+from algebras.utils.android_xml_handler import (
+    read_android_xml_file,
+    write_android_xml_file,
+    write_android_xml_file_in_place
+)
+
+
+class TestAndroidXMLPluralTranslation:
+    """Tests for Android XML plural translation functionality"""
+    
+    def test_android_xml_plurals_are_read_correctly(self):
+        """Test that plural elements are correctly extracted with .__plurals__ suffix"""
+        # Create a temporary XML file with plural elements
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="regular_key">Regular string</string>
+    <plurals name="Quiz.timer_format">
+        <item quantity="one">%1$d minute</item>
+        <item quantity="other">%1$d minutes</item>
+    </plurals>
+    <plurals name="Quiz.passing_score_points_format">
+        <item quantity="one">%1$d point</item>
+        <item quantity="other">%1$d points</item>
+    </plurals>
+    <string name="another_key">Another string</string>
+</resources>"""
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False, encoding='utf-8') as f:
+            temp_file = f.name
+            f.write(xml_content)
+        
+        try:
+            # Read the XML file
+            result = read_android_xml_file(temp_file)
+            
+            # Verify regular strings are read correctly
+            assert "regular_key" in result
+            assert result["regular_key"] == "Regular string"
+            assert "another_key" in result
+            assert result["another_key"] == "Another string"
+            
+            # Verify plural keys have .__plurals__ suffix
+            assert "Quiz.timer_format.__plurals__" in result
+            assert "Quiz.passing_score_points_format.__plurals__" in result
+            
+            # Verify plural values are dictionaries with quantity keys
+            timer_plurals = result["Quiz.timer_format.__plurals__"]
+            assert isinstance(timer_plurals, dict)
+            assert "one" in timer_plurals
+            assert "other" in timer_plurals
+            assert timer_plurals["one"] == "%1$d minute"
+            assert timer_plurals["other"] == "%1$d minutes"
+            
+            points_plurals = result["Quiz.passing_score_points_format.__plurals__"]
+            assert isinstance(points_plurals, dict)
+            assert "one" in points_plurals
+            assert "other" in points_plurals
+            assert points_plurals["one"] == "%1$d point"
+            assert points_plurals["other"] == "%1$d points"
+            
+        finally:
+            os.unlink(temp_file)
+    
+    def test_xml_recognized_as_flat_format(self, monkeypatch):
+        """Test that .xml files are recognized as flat format in translation logic"""
+        # Mock Config
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.load.return_value = {}
+        mock_config.get_api_config.return_value = {"provider": "algebras-ai"}
+        mock_config.get_base_url.return_value = "https://platform.algebras.ai"
+        mock_config.get_source_language.return_value = "en"
+        mock_config.get_setting.return_value = ""
+        mock_config.has_setting.return_value = False
+
+        monkeypatch.setattr("algebras.config.Config", lambda *args, **kwargs: mock_config)
+        monkeypatch.setenv("ALGEBRAS_API_KEY", "test-api-key")
+
+        # Mock the cache
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+        mock_cache.get_cache_key.return_value = "test-cache-key"
+        monkeypatch.setattr("algebras.services.translator.TranslationCache", lambda: mock_cache)
+
+        translator = Translator()
+
+        # Mock batch processor
+        from algebras.services.batch_processor import BatchResult
+        mock_batch_processor = MagicMock()
+        mock_batch_processor.process.return_value = BatchResult(
+            translations=["Bonjour"],
+            error_stats={"5xx": [], "429": [], "other": []},
+            failed_batches=[],
+            successful_batches=1,
+            total_batches=1,
+        )
+        translator._batch_processor = mock_batch_processor
+
+        # Test with a source file path ending in .xml
+        source_content = {
+            "test_key": "Hello"
+        }
+        target_content = {}
+        missing_keys = ["test_key"]
+        
+        # This should work because .xml is now recognized as flat format
+        result = translator.translate_missing_keys_batch(
+            source_content,
+            target_content,
+            missing_keys,
+            "fr",
+            source_file_path="strings/values/test.xml"
+        )
+        
+        # Verify the key was translated
+        assert "test_key" in result
+        assert result["test_key"] == "Bonjour"
+    
+    def test_translate_missing_plural_keys_batch(self, monkeypatch):
+        """
+        Core regression test: Verify plural keys are correctly translated.
+        
+        This test would have caught the original bug where plural keys
+        (stored as dicts) were being skipped during translation.
+        """
+        # Mock Config
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.load.return_value = {}
+        mock_config.get_api_config.return_value = {"provider": "algebras-ai"}
+        mock_config.get_base_url.return_value = "https://platform.algebras.ai"
+        mock_config.get_source_language.return_value = "en"
+        mock_config.get_setting.return_value = ""
+        mock_config.has_setting.return_value = False
+
+        monkeypatch.setattr("algebras.config.Config", lambda *args, **kwargs: mock_config)
+        monkeypatch.setenv("ALGEBRAS_API_KEY", "test-api-key")
+
+        # Mock the cache
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+        mock_cache.get_cache_key.return_value = "test-cache-key"
+        monkeypatch.setattr("algebras.services.translator.TranslationCache", lambda: mock_cache)
+
+        translator = Translator()
+
+        # Mock batch processor to return German translations
+        from algebras.services.batch_processor import BatchResult
+        mock_batch_processor = MagicMock()
+        
+        def mock_process(texts, source_lang, target_lang, ui_safe=False, glossary_id="", on_batch_complete=None, translate_text_func=None):
+            translations = []
+            for text in texts:
+                # Simulate German translations
+                translation_map = {
+                    "%1$d minute": "%1$d Minute",
+                    "%1$d minutes": "%1$d Minuten",
+                }
+                translations.append(translation_map.get(text, text))
+            return BatchResult(
+                translations=translations,
+                error_stats={"5xx": [], "429": [], "other": []},
+                failed_batches=[],
+                successful_batches=1,
+                total_batches=1,
+            )
+        
+        mock_batch_processor.process = mock_process
+        translator._batch_processor = mock_batch_processor
+
+        # Source content with plural key (how it's stored internally)
+        source_content = {
+            "Quiz.timer_format.__plurals__": {
+                "one": "%1$d minute",
+                "other": "%1$d minutes"
+            }
+        }
+        
+        target_content = {}
+        missing_keys = ["Quiz.timer_format.__plurals__"]
+        
+        # Translate missing plural keys
+        result = translator.translate_missing_keys_batch(
+            source_content,
+            target_content,
+            missing_keys,
+            "de",
+            source_file_path="strings/values/test.xml"
+        )
+        
+        # Verify plural key is in result
+        assert "Quiz.timer_format.__plurals__" in result
+        
+        # Verify it's a dictionary with the correct structure
+        assert isinstance(result["Quiz.timer_format.__plurals__"], dict)
+        
+        # Verify both plural forms were translated
+        plural_dict = result["Quiz.timer_format.__plurals__"]
+        assert "one" in plural_dict
+        assert "other" in plural_dict
+        assert plural_dict["one"] == "%1$d Minute"
+        assert plural_dict["other"] == "%1$d Minuten"
+    
+    def test_translate_multiple_plural_keys_batch(self, monkeypatch):
+        """Test translating multiple plural keys simultaneously with regular strings"""
+        # Mock Config
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.load.return_value = {}
+        mock_config.get_api_config.return_value = {"provider": "algebras-ai"}
+        mock_config.get_base_url.return_value = "https://platform.algebras.ai"
+        mock_config.get_source_language.return_value = "en"
+        mock_config.get_setting.return_value = ""
+        mock_config.has_setting.return_value = False
+
+        monkeypatch.setattr("algebras.config.Config", lambda *args, **kwargs: mock_config)
+        monkeypatch.setenv("ALGEBRAS_API_KEY", "test-api-key")
+
+        # Mock the cache
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+        mock_cache.get_cache_key.return_value = "test-cache-key"
+        monkeypatch.setattr("algebras.services.translator.TranslationCache", lambda: mock_cache)
+
+        translator = Translator()
+
+        # Mock batch processor
+        from algebras.services.batch_processor import BatchResult
+        mock_batch_processor = MagicMock()
+        
+        def mock_process(texts, source_lang, target_lang, ui_safe=False, glossary_id="", on_batch_complete=None, translate_text_func=None):
+            translations = []
+            translation_map = {
+                "%1$d minute": "%1$d Minute",
+                "%1$d minutes": "%1$d Minuten",
+                "%1$d point": "%1$d Punkt",
+                "%1$d points": "%1$d Punkte",
+                "%1$d point scored on the question": "%1$d Punkt für die Frage erzielt",
+                "%1$d points scored on the question": "%1$d Punkte für die Frage erzielt",
+                "Start": "Anfang",
+                "Finish": "Fertig",
+            }
+            for text in texts:
+                translations.append(translation_map.get(text, text))
+            return BatchResult(
+                translations=translations,
+                error_stats={"5xx": [], "429": [], "other": []},
+                failed_batches=[],
+                successful_batches=1,
+                total_batches=1,
+            )
+        
+        mock_batch_processor.process = mock_process
+        translator._batch_processor = mock_batch_processor
+
+        # Source content with multiple plural keys and regular strings
+        source_content = {
+            "Quiz.start": "Start",
+            "Quiz.timer_format.__plurals__": {
+                "one": "%1$d minute",
+                "other": "%1$d minutes"
+            },
+            "Quiz.passing_score_points_format.__plurals__": {
+                "one": "%1$d point",
+                "other": "%1$d points"
+            },
+            "Quiz.finish": "Finish",
+            "Quiz.question_score_format.__plurals__": {
+                "one": "%1$d point scored on the question",
+                "other": "%1$d points scored on the question"
+            }
+        }
+        
+        target_content = {}
+        missing_keys = [
+            "Quiz.start",
+            "Quiz.timer_format.__plurals__",
+            "Quiz.passing_score_points_format.__plurals__",
+            "Quiz.finish",
+            "Quiz.question_score_format.__plurals__"
+        ]
+        
+        # Translate all missing keys
+        result = translator.translate_missing_keys_batch(
+            source_content,
+            target_content,
+            missing_keys,
+            "de",
+            source_file_path="strings/values/test.xml"
+        )
+        
+        # Verify regular strings were translated
+        assert result["Quiz.start"] == "Anfang"
+        assert result["Quiz.finish"] == "Fertig"
+        
+        # Verify all plural keys were translated correctly
+        assert "Quiz.timer_format.__plurals__" in result
+        assert isinstance(result["Quiz.timer_format.__plurals__"], dict)
+        assert result["Quiz.timer_format.__plurals__"]["one"] == "%1$d Minute"
+        assert result["Quiz.timer_format.__plurals__"]["other"] == "%1$d Minuten"
+        
+        assert "Quiz.passing_score_points_format.__plurals__" in result
+        assert isinstance(result["Quiz.passing_score_points_format.__plurals__"], dict)
+        assert result["Quiz.passing_score_points_format.__plurals__"]["one"] == "%1$d Punkt"
+        assert result["Quiz.passing_score_points_format.__plurals__"]["other"] == "%1$d Punkte"
+        
+        assert "Quiz.question_score_format.__plurals__" in result
+        assert isinstance(result["Quiz.question_score_format.__plurals__"], dict)
+        assert result["Quiz.question_score_format.__plurals__"]["one"] == "%1$d Punkt für die Frage erzielt"
+        assert result["Quiz.question_score_format.__plurals__"]["other"] == "%1$d Punkte für die Frage erzielt"
+    
+    def test_write_android_xml_with_plurals(self):
+        """Test that write_android_xml_file_in_place correctly handles plural keys"""
+        # Create initial XML file with one plural
+        initial_xml = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="regular_key">Regular value</string>
+    <plurals name="Plural.tasks">
+        <item quantity="one">%1$d task</item>
+        <item quantity="other">%1$d tasks</item>
+    </plurals>
+</resources>"""
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False, encoding='utf-8') as f:
+            temp_file = f.name
+            f.write(initial_xml)
+        
+        try:
+            # Update with new plural keys
+            updated_content = {
+                "regular_key": "Regular value",
+                "Plural.tasks.__plurals__": {
+                    "one": "%1$d task",
+                    "other": "%1$d tasks"
+                },
+                "Quiz.timer_format.__plurals__": {
+                    "one": "%1$d Minute",
+                    "other": "%1$d Minuten"
+                }
+            }
+            
+            # Write in place - should add the new plural
+            write_android_xml_file_in_place(
+                temp_file,
+                updated_content,
+                keys_to_update={"Quiz.timer_format.__plurals__"}
+            )
+            
+            # Read back and verify
+            result = read_android_xml_file(temp_file)
+            
+            # Verify both plurals exist
+            assert "Plural.tasks.__plurals__" in result
+            assert "Quiz.timer_format.__plurals__" in result
+            
+            # Verify the new plural was added correctly
+            timer_plural = result["Quiz.timer_format.__plurals__"]
+            assert isinstance(timer_plural, dict)
+            assert timer_plural["one"] == "%1$d Minute"
+            assert timer_plural["other"] == "%1$d Minuten"
+            
+        finally:
+            os.unlink(temp_file)

--- a/tests/test_android_xml_plural_translation.py
+++ b/tests/test_android_xml_plural_translation.py
@@ -377,3 +377,303 @@ class TestAndroidXMLPluralTranslation:
             
         finally:
             os.unlink(temp_file)
+    
+    def test_in_place_update_adds_missing_plural_keys(self, monkeypatch):
+        """
+        Integration test: Full flow from source to target with missing plural keys.
+        
+        This simulates the exact scenario from the bug report:
+        - Source XML has plural keys
+        - Target XML is missing those plural keys
+        - Translation process should add translated plurals to target
+        """
+        # Mock Config
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.load.return_value = {}
+        mock_config.get_api_config.return_value = {"provider": "algebras-ai"}
+        mock_config.get_base_url.return_value = "https://platform.algebras.ai"
+        mock_config.get_source_language.return_value = "en"
+        mock_config.get_setting.return_value = ""
+        mock_config.has_setting.return_value = False
+
+        monkeypatch.setattr("algebras.config.Config", lambda *args, **kwargs: mock_config)
+        monkeypatch.setenv("ALGEBRAS_API_KEY", "test-api-key")
+
+        # Mock the cache
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+        mock_cache.get_cache_key.return_value = "test-cache-key"
+        monkeypatch.setattr("algebras.services.translator.TranslationCache", lambda: mock_cache)
+
+        translator = Translator()
+
+        # Mock batch processor
+        from algebras.services.batch_processor import BatchResult
+        mock_batch_processor = MagicMock()
+        
+        def mock_process(texts, source_lang, target_lang, ui_safe=False, glossary_id="", on_batch_complete=None, translate_text_func=None):
+            translations = []
+            translation_map = {
+                "%1$d minute": "%1$d Minute",
+                "%1$d minutes": "%1$d Minuten",
+                "%1$d point": "%1$d Punkt",
+                "%1$d points": "%1$d Punkte",
+            }
+            for text in texts:
+                translations.append(translation_map.get(text, text))
+            return BatchResult(
+                translations=translations,
+                error_stats={"5xx": [], "429": [], "other": []},
+                failed_batches=[],
+                successful_batches=1,
+                total_batches=1,
+            )
+        
+        mock_batch_processor.process = mock_process
+        translator._batch_processor = mock_batch_processor
+
+        # Create source XML with plural keys
+        source_xml = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="Quiz.answer">Answer</string>
+    <plurals name="Quiz.timer_format">
+        <item quantity="one">%1$d minute</item>
+        <item quantity="other">%1$d minutes</item>
+    </plurals>
+    <plurals name="Quiz.passing_score_points_format">
+        <item quantity="one">%1$d point</item>
+        <item quantity="other">%1$d points</item>
+    </plurals>
+</resources>"""
+        
+        # Create target XML without the new plural keys
+        target_xml = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="Quiz.answer">Antwort</string>
+</resources>"""
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False, encoding='utf-8') as f:
+            source_file = f.name
+            f.write(source_xml)
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False, encoding='utf-8') as f:
+            target_file = f.name
+            f.write(target_xml)
+        
+        try:
+            # Read source and target content
+            source_content = read_android_xml_file(source_file)
+            target_content = read_android_xml_file(target_file)
+            
+            # Identify missing keys
+            missing_keys = set(source_content.keys()) - set(target_content.keys())
+            assert "Quiz.timer_format.__plurals__" in missing_keys
+            assert "Quiz.passing_score_points_format.__plurals__" in missing_keys
+            
+            # Translate missing keys
+            translated_content = translator.translate_missing_keys_batch(
+                source_content,
+                target_content,
+                missing_keys,
+                "de",
+                source_file_path=source_file
+            )
+            
+            # Write translated content back to target file
+            write_android_xml_file_in_place(
+                target_file,
+                translated_content,
+                keys_to_update=missing_keys
+            )
+            
+            # Read target file again and verify plurals were added
+            final_target_content = read_android_xml_file(target_file)
+            
+            # Verify Quiz.answer is still there
+            assert "Quiz.answer" in final_target_content
+            
+            # Verify both plural keys were added
+            assert "Quiz.timer_format.__plurals__" in final_target_content
+            assert "Quiz.passing_score_points_format.__plurals__" in final_target_content
+            
+            # Verify plural structures are correct
+            timer_plural = final_target_content["Quiz.timer_format.__plurals__"]
+            assert isinstance(timer_plural, dict)
+            assert timer_plural["one"] == "%1$d Minute"
+            assert timer_plural["other"] == "%1$d Minuten"
+            
+            points_plural = final_target_content["Quiz.passing_score_points_format.__plurals__"]
+            assert isinstance(points_plural, dict)
+            assert points_plural["one"] == "%1$d Punkt"
+            assert points_plural["other"] == "%1$d Punkte"
+            
+        finally:
+            os.unlink(source_file)
+            os.unlink(target_file)
+    
+    def test_plural_with_empty_forms(self, monkeypatch):
+        """Test handling plurals where some quantity forms are empty strings"""
+        # Mock Config
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.load.return_value = {}
+        mock_config.get_api_config.return_value = {"provider": "algebras-ai"}
+        mock_config.get_base_url.return_value = "https://platform.algebras.ai"
+        mock_config.get_source_language.return_value = "en"
+        mock_config.get_setting.return_value = ""
+        mock_config.has_setting.return_value = False
+
+        monkeypatch.setattr("algebras.config.Config", lambda *args, **kwargs: mock_config)
+        monkeypatch.setenv("ALGEBRAS_API_KEY", "test-api-key")
+
+        # Mock the cache
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+        mock_cache.get_cache_key.return_value = "test-cache-key"
+        monkeypatch.setattr("algebras.services.translator.TranslationCache", lambda: mock_cache)
+
+        translator = Translator()
+
+        # Mock batch processor
+        from algebras.services.batch_processor import BatchResult
+        mock_batch_processor = MagicMock()
+        mock_batch_processor.process.return_value = BatchResult(
+            translations=["%1$d Minuten"],
+            error_stats={"5xx": [], "429": [], "other": []},
+            failed_batches=[],
+            successful_batches=1,
+            total_batches=1,
+        )
+        translator._batch_processor = mock_batch_processor
+
+        # Source with one empty plural form
+        source_content = {
+            "Quiz.timer_format.__plurals__": {
+                "one": "",  # Empty
+                "other": "%1$d minutes"
+            }
+        }
+        
+        target_content = {}
+        missing_keys = ["Quiz.timer_format.__plurals__"]
+        
+        result = translator.translate_missing_keys_batch(
+            source_content,
+            target_content,
+            missing_keys,
+            "de",
+            source_file_path="strings/values/test.xml"
+        )
+        
+        # Empty form should be preserved
+        assert "Quiz.timer_format.__plurals__" in result
+        plural_dict = result["Quiz.timer_format.__plurals__"]
+        assert "other" in plural_dict
+        assert plural_dict["other"] == "%1$d Minuten"
+    
+    def test_plural_with_single_form(self):
+        """Test handling a degenerate plural with only one quantity"""
+        xml_content = """<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <plurals name="Test.single_plural">
+        <item quantity="other">%1$d items</item>
+    </plurals>
+</resources>"""
+        
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.xml', delete=False, encoding='utf-8') as f:
+            temp_file = f.name
+            f.write(xml_content)
+        
+        try:
+            result = read_android_xml_file(temp_file)
+            
+            # Should still be stored as a plural
+            assert "Test.single_plural.__plurals__" in result
+            plural_dict = result["Test.single_plural.__plurals__"]
+            assert isinstance(plural_dict, dict)
+            assert len(plural_dict) == 1
+            assert plural_dict["other"] == "%1$d items"
+            
+        finally:
+            os.unlink(temp_file)
+    
+    def test_mixed_plurals_and_strings(self, monkeypatch):
+        """Test that regular strings are not affected by plural logic"""
+        # Mock Config
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.load.return_value = {}
+        mock_config.get_api_config.return_value = {"provider": "algebras-ai"}
+        mock_config.get_base_url.return_value = "https://platform.algebras.ai"
+        mock_config.get_source_language.return_value = "en"
+        mock_config.get_setting.return_value = ""
+        mock_config.has_setting.return_value = False
+
+        monkeypatch.setattr("algebras.config.Config", lambda *args, **kwargs: mock_config)
+        monkeypatch.setenv("ALGEBRAS_API_KEY", "test-api-key")
+
+        # Mock the cache
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+        mock_cache.get_cache_key.return_value = "test-cache-key"
+        monkeypatch.setattr("algebras.services.translator.TranslationCache", lambda: mock_cache)
+
+        translator = Translator()
+
+        # Mock batch processor
+        from algebras.services.batch_processor import BatchResult
+        mock_batch_processor = MagicMock()
+        
+        def mock_process(texts, source_lang, target_lang, ui_safe=False, glossary_id="", on_batch_complete=None, translate_text_func=None):
+            translations = []
+            translation_map = {
+                "Start Quiz": "Quiz starten",
+                "Finish Quiz": "Quiz beenden",
+                "%1$d minute": "%1$d Minute",
+                "%1$d minutes": "%1$d Minuten",
+            }
+            for text in texts:
+                translations.append(translation_map.get(text, text))
+            return BatchResult(
+                translations=translations,
+                error_stats={"5xx": [], "429": [], "other": []},
+                failed_batches=[],
+                successful_batches=1,
+                total_batches=1,
+            )
+        
+        mock_batch_processor.process = mock_process
+        translator._batch_processor = mock_batch_processor
+
+        # Mix of regular strings and plurals
+        source_content = {
+            "Quiz.start": "Start Quiz",
+            "Quiz.timer_format.__plurals__": {
+                "one": "%1$d minute",
+                "other": "%1$d minutes"
+            },
+            "Quiz.finish": "Finish Quiz"
+        }
+        
+        target_content = {}
+        missing_keys = ["Quiz.start", "Quiz.timer_format.__plurals__", "Quiz.finish"]
+        
+        result = translator.translate_missing_keys_batch(
+            source_content,
+            target_content,
+            missing_keys,
+            "de",
+            source_file_path="strings/values/test.xml"
+        )
+        
+        # Verify regular strings remain strings
+        assert isinstance(result["Quiz.start"], str)
+        assert result["Quiz.start"] == "Quiz starten"
+        assert isinstance(result["Quiz.finish"], str)
+        assert result["Quiz.finish"] == "Quiz beenden"
+        
+        # Verify plural remains a dict
+        assert isinstance(result["Quiz.timer_format.__plurals__"], dict)
+        assert result["Quiz.timer_format.__plurals__"]["one"] == "%1$d Minute"
+        assert result["Quiz.timer_format.__plurals__"]["other"] == "%1$d Minuten"


### PR DESCRIPTION
The issue customers encountered: plurals translation doesn't work when target file already exists.

Key problem was that plurals stored as dict, not as strings and that's why were ignored during tranlsation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core translation mapping logic for batch updates and adds special-case plural reconstruction; mistakes could miswrite keys/structures in updated localization files, though coverage is improved via new tests.
> 
> **Overview**
> Fixes a bug where Android XML plural resources (stored internally as `key.__plurals__` dicts) were skipped when translating *missing* (and similarly *outdated*) keys by translating each plural form separately and rebuilding the plural dict in the updated output.
> 
> Adds a comprehensive regression test suite covering reading/writing plural XML entries, in-place updates into existing target files, and edge cases like empty or single-form plurals, plus new Android and iOS localization example files/README. Also includes a minor stray comment change in `update_command.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc7629f89a2f7ec2e4c21e988e0fa44bed39f8d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->