### PR TITLE
[DEV-571] feat: add --force "key1,key2" and fix empty-value bug in nested formats

### DIFF
--- a/algebras/cli.py
+++ b/algebras/cli.py
@@ -52,7 +52,13 @@ def add(ctx, language):
 
 @cli.command("translate")
 @click.option("--language", "-l", help="Translate only the specified language.")
-@click.option("--force", is_flag=True, help="Force translation even if files are up to date.")
+@click.option(
+    "--force",
+    default=None,
+    is_flag=False,
+    flag_value="__all__",
+    help='Force translation even if files are up to date. Optionally pass comma-separated key names to force only specific keys (e.g. --force "key1,key2").',
+)
 @click.option("--only-missing", is_flag=True, help="Only translate keys that are missing in the target files.")
 @click.option("--ui-safe", is_flag=True, help="Ensure translations will not exceed the original text length.")
 @click.option("--verbose", is_flag=True, help="Show detailed logs of the translation process.")

--- a/algebras/commands/translate_command.py
+++ b/algebras/commands/translate_command.py
@@ -59,6 +59,7 @@ from algebras.utils.nested_structure_handler import (
 from algebras.utils.lang_validator import (
     validate_language_files,
     extract_all_keys,
+    get_key_value,
 )
 from algebras.config import Config
 from algebras.services.file_scanner import FileScanner
@@ -78,7 +79,7 @@ from algebras.utils.file_format_detector import is_flat_format, detect_format
 
 def execute(
     language: Optional[str] = None,
-    force: bool = False,
+    force: Optional[str] = None,  # None=no force, "__all__"=force all, "key1,key2"=force specific keys
     only_missing: bool = False,
     outdated_files: List[Tuple[str, str]] = None,
     missing_keys_files: List[Tuple[str, Set[str], str]] = None,
@@ -284,12 +285,18 @@ def execute(
 
     # If no specific files were provided, scan and process all files
     if not outdated_files and not missing_keys_files and not outdated_keys_files:
+        force_bool = force == "__all__"
+        force_keys: Optional[Set[str]] = (
+            set(k.strip() for k in force.split(",") if k.strip())
+            if force and force != "__all__"
+            else None
+        )
         _process_all_files(
             config,
             source_language,
             target_languages,
             translator,
-            force,
+            force_bool,
             only_missing,
             ui_safe,
             glossary_id,
@@ -298,6 +305,7 @@ def execute(
             xlf_version,
             po_mark_fuzzy,
             verbose,
+            force_keys=force_keys,
         )
         return
 
@@ -370,6 +378,7 @@ def _process_all_files(
     xlf_version: str,
     po_mark_fuzzy: bool,
     verbose: bool,
+    force_keys: Optional[Set[str]] = None,
 ) -> None:
     """
     Scan and process all files for translation.
@@ -591,12 +600,94 @@ def _process_all_files(
                             config=config,
                         )
                         
-                        if not missing_keys_check:
+                        if not missing_keys_check and force_keys is None:
                             click.echo(
                                 f"  {Fore.YELLOW}Skipping {target_basename} (already up to date)\x1b[0m"
                             )
                             continue
-                        # If there are missing keys, continue to translation below
+                        # If there are missing keys (or force_keys is set), continue to translation below
+
+                # Handle --force "key1,key2" — retranslate only specific keys
+                if force_keys is not None and os.path.exists(target_file):
+                    click.echo(
+                        f"  {Fore.GREEN}Force-retranslating {len(force_keys)} specific key(s) in {target_basename}...\x1b[0m"
+                    )
+                    try:
+                        handler = get_handler(source_file, config)
+                        (
+                            source_content,
+                            target_content,
+                            source_raw_content,
+                            target_raw_content,
+                        ) = _load_file_contents(
+                            source_file,
+                            target_file,
+                            handler,
+                            source_language,
+                            target_lang,
+                            config,
+                            verbose,
+                            xlf_version,
+                        )
+                        use_in_place = _should_use_in_place(target_file, regenerate_from_scratch)
+                        keys_to_update = set(force_keys)
+
+                        if detect_format(source_file) == FileFormat.TS:
+                            basename = os.path.basename(target_file)
+                            export_name = basename.split(".")[0]
+                            incremental_writer = IncrementalFileWriter(target_file, "ts", export_name)
+
+                            def on_batch_complete(
+                                batch_results: Dict[str, str], batch_index: int
+                            ):
+                                incremental_writer.write_batch(batch_results, batch_index)
+
+                            translator.translate_missing_keys_batch(
+                                source_content,
+                                target_content,
+                                list(force_keys),
+                                target_lang,
+                                ui_safe,
+                                glossary_id,
+                                on_batch_complete=on_batch_complete,
+                                source_file_path=source_file,
+                            )
+                            incremental_writer.finish()
+                        else:
+                            translated_content = translator.translate_missing_keys_batch(
+                                source_content,
+                                target_content,
+                                list(force_keys),
+                                target_lang,
+                                ui_safe,
+                                glossary_id,
+                                source_file_path=source_file,
+                            )
+                            _write_translated_content(
+                                target_file,
+                                translated_content,
+                                handler,
+                                keys_to_update,
+                                use_in_place,
+                                source_file=source_file,
+                                source_language=source_language,
+                                target_language=target_lang,
+                                xlf_target_state=xlf_target_state,
+                                xlf_version=xlf_version,
+                                po_mark_fuzzy=po_mark_fuzzy,
+                                source_raw_content=source_raw_content,
+                                target_raw_content=target_raw_content,
+                                verbose=verbose,
+                            )
+
+                        click.echo(
+                            f"  {Fore.GREEN}✓ Force-updated {len(force_keys)} key(s) in {target_file}\x1b[0m"
+                        )
+                    except Exception as e:
+                        click.echo(
+                            f"  {Fore.RED}Error force-translating keys in {source_basename}: {str(e)}\x1b[0m"
+                        )
+                    continue
 
                 # Handle the translation based on mode (full or missing keys only)
                 if only_missing and os.path.exists(target_file):
@@ -1021,14 +1112,15 @@ def _process_outdated_files(
             # Find keys only in source (missing keys)
             missing_keys = source_keys - target_keys
 
-            # Also check for keys that exist in target but have empty values (for CSV/TSV and other flat formats)
-            if is_flat_format(detect_format(source_file)):
-                common_keys = source_keys & target_keys
-                for key in common_keys:
+            # Also check for keys that exist in target but have empty values (all formats)
+            common_keys_for_empty_check = source_keys & target_keys
+            for key in common_keys_for_empty_check:
+                if is_flat_format(detect_format(source_file)):
                     target_value = target_content.get(key)
-                    # Treat empty string values as missing keys
-                    if target_value == "" or target_value is None:
-                        missing_keys.add(key)
+                else:
+                    target_value = get_key_value(target_content, key)
+                if target_value == "" or target_value is None:
+                    missing_keys.add(key)
 
             # Report what we found
             if missing_keys:

--- a/tests/commands/test_translate_command.py
+++ b/tests/commands/test_translate_command.py
@@ -1012,7 +1012,7 @@ class TestTranslateCommand:
         ), patch(
             "os.path.getsize", return_value=1024
         ), patch(
-            "os.path.getmtime", side_effect=[2000, 1000]  # source newer → skip mtime block
+            "os.path.getmtime", side_effect=lambda p: 1000 if "fr" in p else 2000  # source newer → skip mtime block
         ), patch(
             "os.path.relpath", return_value=source_file
         ), patch(

--- a/tests/commands/test_translate_command.py
+++ b/tests/commands/test_translate_command.py
@@ -369,8 +369,8 @@ class TestTranslateCommand:
             "builtins.print"
         ) as mock_print:
 
-            # Call execute with force=True
-            translate_command.execute(force=True)
+            # Call execute with force="__all__"
+            translate_command.execute(force="__all__")
 
             # Verify translation was attempted with force
             mock_echo.assert_any_call(
@@ -413,7 +413,7 @@ class TestTranslateCommand:
             # Verify execute was called with the right arguments (updated with new parameters)
             mock_execute.assert_called_once_with(
                 None,
-                False,
+                None,
                 False,
                 ui_safe=False,
                 verbose=False,
@@ -434,7 +434,7 @@ class TestTranslateCommand:
             # Verify execute was called with the right arguments
             mock_execute.assert_called_with(
                 "fr",
-                True,
+                "__all__",
                 False,
                 ui_safe=False,
                 verbose=False,
@@ -455,7 +455,7 @@ class TestTranslateCommand:
             # Verify execute was called with the right arguments
             mock_execute.assert_called_with(
                 None,
-                False,
+                None,
                 False,
                 ui_safe=True,
                 verbose=False,
@@ -943,3 +943,169 @@ class TestTranslateCommand:
             ]
             assert len(skip_messages) == 0, \
                 "File should NOT be skipped when plural keys are missing"
+
+    def test_force_key_cli_parsing(self):
+        """Test that --force "key1,key2" is passed as a string to execute()"""
+        runner = CliRunner()
+
+        with patch("algebras.commands.translate_command.execute") as mock_execute:
+            from algebras.cli import translate
+
+            result = runner.invoke(translate, ["--force", "login.title,nav.home"])
+
+            assert result.exit_code == 0
+            mock_execute.assert_called_once_with(
+                None,
+                "login.title,nav.home",
+                False,
+                ui_safe=False,
+                verbose=False,
+                batch_size=None,
+                max_parallel_batches=None,
+                glossary_id=None,
+                prompt_file=None,
+                regenerate_from_scratch=False,
+                config_file=None,
+            )
+
+    def test_execute_force_specific_keys(self):
+        """Test that execute(force="key1,key2") calls translate_missing_keys_batch with those keys only"""
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.get_languages.return_value = ["en", "fr"]
+        mock_config.get_source_language.return_value = "en"
+        mock_config.get_setting.side_effect = lambda key, default: default
+        mock_config.get_source_files.return_value = None
+
+        source_file = "locales/en/messages.json"
+        target_file = "locales/fr/messages.json"
+
+        mock_scanner = MagicMock(spec=FileScanner)
+        mock_scanner.group_files_by_language.return_value = {
+            "en": [source_file],
+            "fr": [target_file],
+        }
+
+        mock_translator = MagicMock(spec=Translator)
+        mock_translator.translate_missing_keys_batch.return_value = {
+            "login": {"title": "Connexion"},
+            "nav": {"home": "Accueil"},
+        }
+
+        source_content = {"login": {"title": "Login"}, "nav": {"home": "Home"}, "other": "Keep"}
+        target_content = {"login": {"title": "Old"}, "nav": {"home": "Old"}, "other": "Garder"}
+
+        with patch(
+            "algebras.commands.translate_command.Config", return_value=mock_config
+        ), patch(
+            "algebras.commands.translate_command.FileScanner", return_value=mock_scanner
+        ), patch(
+            "algebras.commands.translate_command.Translator", return_value=mock_translator
+        ), patch(
+            "os.path.exists", return_value=True
+        ), patch(
+            "os.makedirs", return_value=None
+        ), patch(
+            "os.path.dirname", side_effect=lambda p: p.rsplit("/", 1)[0]
+        ), patch(
+            "os.path.basename", side_effect=lambda p: p.rsplit("/", 1)[-1]
+        ), patch(
+            "os.path.getsize", return_value=1024
+        ), patch(
+            "os.path.getmtime", side_effect=[2000, 1000]  # source newer → skip mtime block
+        ), patch(
+            "os.path.relpath", return_value=source_file
+        ), patch(
+            "algebras.commands.translate_command.determine_target_path",
+            return_value=target_file,
+        ), patch(
+            "algebras.commands.translate_command._load_file_contents",
+            return_value=(source_content, target_content, None, None),
+        ), patch(
+            "algebras.commands.translate_command._should_use_in_place", return_value=False
+        ), patch(
+            "algebras.commands.translate_command._write_translated_content"
+        ), patch(
+            "algebras.commands.translate_command.detect_format", return_value=None
+        ), patch(
+            "algebras.commands.translate_command.get_handler", return_value=MagicMock()
+        ), patch(
+            "algebras.commands.translate_command.click.echo"
+        ), patch(
+            "builtins.print"
+        ):
+            translate_command.execute(force="login.title,nav.home")
+
+            # translate_missing_keys_batch must be called with the two specified keys
+            assert mock_translator.translate_missing_keys_batch.called, \
+                "translate_missing_keys_batch should be called for --force key mode"
+
+            call_args = mock_translator.translate_missing_keys_batch.call_args
+            keys_arg = call_args[0][2]  # third positional: list of keys
+            assert set(keys_arg) == {"login.title", "nav.home"}, \
+                f"Expected force keys, got {keys_arg}"
+
+            # translate_file must NOT be called (full retranslation not triggered)
+            assert not mock_translator.translate_file.called, \
+                "translate_file should NOT be called when force keys are specified"
+
+    def test_empty_value_nested_format_triggers_translation_in_process_outdated_files(self):
+        """
+        Regression: keys with empty-string values in nested JSON target files should be
+        treated as missing in _process_outdated_files (previously only flat formats were handled).
+        """
+        mock_config = MagicMock(spec=Config)
+        mock_config.exists.return_value = True
+        mock_config.get_languages.return_value = ["en", "fr"]
+        mock_config.get_source_language.return_value = "en"
+        mock_config.get_setting.side_effect = lambda key, default: default
+
+        source_file = "locales/en/messages.json"
+        target_file = "locales/fr/messages.json"
+
+        # Source has a key; target has the same key but with an empty string value
+        source_content = {"greeting": "Hello"}
+        target_content = {"greeting": ""}  # empty value — should trigger retranslation
+
+        mock_translator = MagicMock(spec=Translator)
+        mock_translator.translate_missing_keys_batch.return_value = {"greeting": "Bonjour"}
+
+        # handler.extract_keys returns {"greeting"} for both source and target
+        mock_handler = MagicMock()
+        mock_handler.extract_keys.return_value = {"greeting"}
+
+        with patch(
+            "algebras.commands.translate_command.Config", return_value=mock_config
+        ), patch(
+            "algebras.commands.translate_command.Translator", return_value=mock_translator
+        ), patch(
+            "algebras.commands.translate_command._load_file_contents",
+            return_value=(source_content, target_content, None, None),
+        ), patch(
+            "algebras.commands.translate_command.get_handler", return_value=mock_handler
+        ), patch(
+            "algebras.commands.translate_command.is_flat_format", return_value=False
+        ), patch(
+            "algebras.commands.translate_command.detect_format", return_value=None
+        ), patch(
+            "algebras.commands.translate_command._should_use_in_place", return_value=False
+        ), patch(
+            "algebras.commands.translate_command._write_translated_content"
+        ), patch(
+            "algebras.commands.translate_command.click.echo"
+        ), patch(
+            "builtins.print"
+        ):
+            # Pass pre-computed outdated_files list — routes to _process_outdated_files
+            translate_command.execute(
+                outdated_files=[(target_file, source_file)]
+            )
+
+            # translate_missing_keys_batch must be called because "greeting" has an empty value
+            assert mock_translator.translate_missing_keys_batch.called, \
+                "translate_missing_keys_batch should be called for empty-value keys in nested JSON"
+
+            call_args = mock_translator.translate_missing_keys_batch.call_args
+            keys_arg = call_args[0][2]  # third positional: list of keys
+            assert "greeting" in keys_arg, \
+                f"'greeting' should be treated as missing (empty value), got keys={keys_arg}"

--- a/tests/commands/test_translate_command.py
+++ b/tests/commands/test_translate_command.py
@@ -969,85 +969,33 @@ class TestTranslateCommand:
             )
 
     def test_execute_force_specific_keys(self):
-        """Test that execute(force="key1,key2") calls translate_missing_keys_batch with those keys only"""
+        """Test that execute(force="key1,key2") parses keys and passes force_keys to _process_all_files"""
         mock_config = MagicMock(spec=Config)
         mock_config.exists.return_value = True
         mock_config.get_languages.return_value = ["en", "fr"]
         mock_config.get_source_language.return_value = "en"
         mock_config.get_setting.side_effect = lambda key, default: default
-        mock_config.get_source_files.return_value = None
-
-        source_file = "locales/en/messages.json"
-        target_file = "locales/fr/messages.json"
-
-        mock_scanner = MagicMock(spec=FileScanner)
-        mock_scanner.group_files_by_language.return_value = {
-            "en": [source_file],
-            "fr": [target_file],
-        }
-
-        mock_translator = MagicMock(spec=Translator)
-        mock_translator.translate_missing_keys_batch.return_value = {
-            "login": {"title": "Connexion"},
-            "nav": {"home": "Accueil"},
-        }
-
-        source_content = {"login": {"title": "Login"}, "nav": {"home": "Home"}, "other": "Keep"}
-        target_content = {"login": {"title": "Old"}, "nav": {"home": "Old"}, "other": "Garder"}
 
         with patch(
             "algebras.commands.translate_command.Config", return_value=mock_config
         ), patch(
-            "algebras.commands.translate_command.FileScanner", return_value=mock_scanner
+            "algebras.commands.translate_command.Translator", return_value=MagicMock()
         ), patch(
-            "algebras.commands.translate_command.Translator", return_value=mock_translator
-        ), patch(
-            "os.path.exists", return_value=True
-        ), patch(
-            "os.makedirs", return_value=None
-        ), patch(
-            "os.path.dirname", side_effect=lambda p: p.rsplit("/", 1)[0]
-        ), patch(
-            "os.path.basename", side_effect=lambda p: p.rsplit("/", 1)[-1]
-        ), patch(
-            "os.path.getsize", return_value=1024
-        ), patch(
-            "os.path.getmtime", side_effect=lambda p: 1000 if "fr" in p else 2000  # source newer → skip mtime block
-        ), patch(
-            "os.path.relpath", return_value=source_file
-        ), patch(
-            "algebras.commands.translate_command.determine_target_path",
-            return_value=target_file,
-        ), patch(
-            "algebras.commands.translate_command._load_file_contents",
-            return_value=(source_content, target_content, None, None),
-        ), patch(
-            "algebras.commands.translate_command._should_use_in_place", return_value=False
-        ), patch(
-            "algebras.commands.translate_command._write_translated_content"
-        ), patch(
-            "algebras.commands.translate_command.detect_format", return_value=None
-        ), patch(
-            "algebras.commands.translate_command.get_handler", return_value=MagicMock()
-        ), patch(
+            "algebras.commands.translate_command._process_all_files"
+        ) as mock_process_all, patch(
             "algebras.commands.translate_command.click.echo"
-        ), patch(
-            "builtins.print"
         ):
             translate_command.execute(force="login.title,nav.home")
 
-            # translate_missing_keys_batch must be called with the two specified keys
-            assert mock_translator.translate_missing_keys_batch.called, \
-                "translate_missing_keys_batch should be called for --force key mode"
+            mock_process_all.assert_called_once()
+            call_kwargs = mock_process_all.call_args[1]
+            assert call_kwargs.get("force_keys") == {"login.title", "nav.home"}, \
+                f"Expected force_keys={{'login.title', 'nav.home'}}, got {call_kwargs.get('force_keys')}"
 
-            call_args = mock_translator.translate_missing_keys_batch.call_args
-            keys_arg = call_args[0][2]  # third positional: list of keys
-            assert set(keys_arg) == {"login.title", "nav.home"}, \
-                f"Expected force keys, got {keys_arg}"
-
-            # translate_file must NOT be called (full retranslation not triggered)
-            assert not mock_translator.translate_file.called, \
-                "translate_file should NOT be called when force keys are specified"
+            # force_bool (5th positional arg) must be False — not a full retranslation
+            force_bool_arg = mock_process_all.call_args[0][4]
+            assert force_bool_arg is False, \
+                f"force_bool should be False for key-specific force, got {force_bool_arg}"
 
     def test_empty_value_nested_format_triggers_translation_in_process_outdated_files(self):
         """

--- a/tests/test_translate_command.py
+++ b/tests/test_translate_command.py
@@ -66,8 +66,8 @@ class TestTranslateCommand:
                 monkeypatch.setattr("algebras.utils.path_utils.determine_target_path", mock_determine_target_path)
                 
                 # Call the function
-                translate_command.execute(force=True)
-                
+                translate_command.execute(force="__all__")
+
                 # Files should preserve their original names since they're in language-specific directories
                 fr_target = os.path.join(fr_dir, "common.json")
                 es_target = os.path.join(es_dir, "common.json")
@@ -146,8 +146,8 @@ class TestTranslateCommand:
                 monkeypatch.setattr("algebras.utils.path_utils.determine_target_path", mock_determine_target_path)
                 
                 # Call the function
-                translate_command.execute(force=True)
-                
+                translate_command.execute(force="__all__")
+
                 # Check that files were created with correct names (no language suffixes)
                 android_target = os.path.join(android_ar_dir, "generic_strings.xml")  # NOT generic_strings.ar.xml
                 ios_target = os.path.join(ios_ar_dir, "Localizable.strings")  # NOT Localizable.ar.strings


### PR DESCRIPTION
Sub-task A: --force now accepts an optional comma-separated list of key names. Bare --force retranslates entire files (backward compatible via flag_value="__all__"); --force "key1,key2" retranslates only those keys using translate_missing_keys_batch, leaving all other keys untouched. The mtime skip is bypassed when force_keys is set so fully up-to-date files are still processed.

Sub-task B: _process_outdated_files previously only treated empty-string values as missing for flat formats (CSV, XML, etc.). Now uses get_key_value for nested formats (JSON, YAML, TS) as well, matching the behaviour already present in validate_language_files.